### PR TITLE
Init fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,5 @@
+# 1.0.2
+
+Resolves an issue where using the `init` command with an app key would cause an incorrect `.env` file to be generated and no debug launch configuraition to be created.
+
+Resolves an issue where using the `add-project` command would cause an incorrect `tsconfig.json` file to be generated for the new project. The configuration had the incorrect path to the collection declaration files, preventing the subprojects from accessing their own entities via collections.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-cli",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Command line tools for the Thingworx VSCode Project",
     "bin": {
         "twc": "dist/index.js"

--- a/src/Scripts/add-project.ts
+++ b/src/Scripts/add-project.ts
@@ -115,7 +115,7 @@ function tsConfigDefault() {
             ]
         },
         include: [
-            "../../static/**/*.d.ts",
+            "./static/**/*.d.ts",
             "./src/**/*.d.ts",
             "./src/**/*.ts",
             "../../tw_imports/**/*.d.ts",

--- a/src/Scripts/init.ts
+++ b/src/Scripts/init.ts
@@ -211,7 +211,7 @@ export async function init() {
         fs.writeFileSync(`${cwd}/.env`, envDefault(creationParameters));
 
         // If an app key authentication was selected, create an attach launch configuration
-        if ('appKey' in creationParameters) {
+        if ('thingworxAppKey' in creationParameters) {
             fs.mkdirSync(`${cwd}/.vscode`);
             fs.writeFileSync(`${cwd}/.vscode/launch.json`, JSON.stringify(launchConfigurationDefault(creationParameters), undefined, 4));
         }
@@ -414,7 +414,7 @@ function envDefault(args: CreationParameters): string {
         env += `THINGWORX_PASSWORD=${args.thingworxPassword}\n`;
     }
     else {
-        env += `THINGWORX_APP_KEY=${args.thingworxAppKey}`;
+        env += `THINGWORX_APPKEY=${args.thingworxAppKey}`;
     }
 
     return env;


### PR DESCRIPTION
Resolves an issue where using the `init` command with an app key would cause an incorrect `.env` file to be generated and no debug launch configuraition to be created.

Resolves an issue where using the `add-project` command would cause an incorrect `tsconfig.json` file to be generated for the new project. The configuration had the incorrect path to the collection declaration files, preventing the subprojects from accessing their own entities via collections.