### PR TITLE
Windows fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 1.0.3
+
+Resolves an issue with an improperly declared import that prevented building this project without a local copy of thing transformer.
+
+Resolves an issue that caused multiproject builds to fail on windows systems.
+
 # 1.0.2
 
 Resolves an issue where using the `init` command with an app key would cause an incorrect `.env` file to be generated and no debug launch configuraition to be created.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "bm-thing-cli",
-    "version": "1.0.0",
+    "version": "1.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "bm-thing-cli",
-            "version": "1.0.0",
+            "version": "1.0.3",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "0.5.9",
-                "bm-thing-transformer": "0.18.0-beta.1",
+                "bm-thing-transformer": "0.19.0-beta.1",
                 "dotenv": "^16.0.0",
                 "enquirer": "^2.3.6",
                 "typescript": "4.5.5",
@@ -56,9 +56,9 @@
             }
         },
         "node_modules/bm-thing-transformer": {
-            "version": "0.18.0-beta.1",
-            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-0.18.0-beta.1.tgz",
-            "integrity": "sha512-GOB856filjhZrcFIsftBrsz8FQb5vAdW5/s+ileCy9628c8sg+cWUqIhy3zkZ+XAs+1csEbjIt3EDUFHjSoutw==",
+            "version": "0.19.0-beta.1",
+            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-0.19.0-beta.1.tgz",
+            "integrity": "sha512-se7HQ6vnxjL4gNBZcqBkZK862cdlLjaX9/UL9uec80rDNCcuV/FK0qTsBOCagdLHbZCuhoIlP9SxDoAwcR5geQ==",
             "dependencies": {
                 "typescript": "4.5.5",
                 "xml2js": "^0.4.23"
@@ -148,9 +148,9 @@
             "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
         },
         "bm-thing-transformer": {
-            "version": "0.18.0-beta.1",
-            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-0.18.0-beta.1.tgz",
-            "integrity": "sha512-GOB856filjhZrcFIsftBrsz8FQb5vAdW5/s+ileCy9628c8sg+cWUqIhy3zkZ+XAs+1csEbjIt3EDUFHjSoutw==",
+            "version": "0.19.0-beta.1",
+            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-0.19.0-beta.1.tgz",
+            "integrity": "sha512-se7HQ6vnxjL4gNBZcqBkZK862cdlLjaX9/UL9uec80rDNCcuV/FK0qTsBOCagdLHbZCuhoIlP9SxDoAwcR5geQ==",
             "requires": {
                 "typescript": "4.5.5",
                 "xml2js": "^0.4.23"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-cli",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Command line tools for the Thingworx VSCode Project",
     "bin": {
         "twc": "dist/index.js"
@@ -31,6 +31,6 @@
         "enquirer": "^2.3.6",
         "typescript": "4.5.5",
         "xml2js": "^0.4.23",
-        "bm-thing-transformer": "0.18.0-beta.1"
+        "bm-thing-transformer": "0.19.0-beta.1"
     }
 }

--- a/src/Scripts/upload.ts
+++ b/src/Scripts/upload.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { TWConfig } from '../../../ThingTransformer/dist/@types';
+import { TWConfig } from 'bm-thing-transformer';
 import { TSUtilities } from '../Utilities/TSUtilities';
 import { TWClient } from '../Utilities/TWClient';
 


### PR DESCRIPTION
Resolves an issue with an improperly declared import that prevented building this project without a local copy of thing transformer.

Resolves an issue that caused multiproject builds to fail on windows systems.