### PR TITLE
fix: Add flag to disable version incrementing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,17 +46,18 @@ Arguments:
 ## `upload`
 Usage:
 ```bash
-npx twc upload [--merged|--separate] [--debug] [--remove]
+npx twc upload [--merged|--separate] [--debug] [--remove] [--retainVersion]
 ```
 
 Builds a thingworx extension package from the typescript project, then imports it on the server defined in either the environment or package.json.
 Arguments:
  - `--remove`: If specified, the current version of the extension(s) will be removed prior to installing the new version.
+ - `--retainVersion`: If specified, the version of the extension(s) in the `package.json` is not incremented. Useful if the version is driven out of external tools
 
 ## `deploy`
 Usage:
 ```bash
-npx twc deploy [--merged|--separate] [--debug] [--remove]
+npx twc deploy [--merged|--separate] [--debug] [--remove] [--retainVersion]
 ```
 
 Builds a thingworx extension package from the typescript project, then imports it on the server defined in either the environment or package.json. After the installation is complete, it runs the services marked with the `@deploy` decorator.

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,13 +100,13 @@ else {
 bm-thing-cli <command> [--argument] ...
 
 Available commands:
- * \x1b[1mdeclarations\x1b[0m                                           Builds the collection declarations
- * \x1b[1mwatch\x1b[0m                                                  Watches the source folder and runs declarations on any change
- * \x1b[1mbuild\x1b[0m [--merged] [--separate] [--debug]                Builds the thingworx extension
- * \x1b[1mupload\x1b[0m [--merged] [--separate] [--debug] [--remove]    Builds and uploads the thingworx extension
- * \x1b[1mdeploy\x1b[0m [--merged] [--separate] [--debug] [--remove]    Uploads the extension then runs deployment scripts
- * \x1b[1mremove\x1b[0m [--merged] [--separate]                         Removes the thingworx extension
- * \x1b[1madd-project\x1b[0m                                            Adds a new project to the repository
- * \x1b[1minit\x1b[0m                                                   Initializes a thingworx project in an empty folder
- * \x1b[1mupgrade\x1b[0m                                                Upgrades from a gulp project to a twc project`);
+ * \x1b[1mdeclarations\x1b[0m                                                            Builds the collection declarations
+ * \x1b[1mwatch\x1b[0m                                                                   Watches the source folder and runs declarations on any change
+ * \x1b[1mbuild\x1b[0m [--merged] [--separate] [--debug]                                 Builds the thingworx extension
+ * \x1b[1mupload\x1b[0m [--merged] [--separate] [--debug] [--remove] [--retainVersion]   Builds and uploads the thingworx extension
+ * \x1b[1mdeploy\x1b[0m [--merged] [--separate] [--debug] [--remove] [--retainVersion]   Uploads the extension then runs deployment scripts
+ * \x1b[1mremove\x1b[0m [--merged] [--separate]                                          Removes the thingworx extension
+ * \x1b[1madd-project\x1b[0m                                                             Adds a new project to the repository
+ * \x1b[1minit\x1b[0m                                                                    Initializes a thingworx project in an empty folder
+ * \x1b[1mupgrade\x1b[0m                                                                 Upgrades from a gulp project to a twc project`);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,10 @@ async function main() {
         // The following 2 commands run a very similar sequence of steps
         case Commands.upload:
         case Commands.deploy:
-            await incrementVersion();
+            // If the argument is present, don't increment the version 
+            if (!args.includes('--retainVersion')) {
+                await incrementVersion();
+            }
             await declarations();
             const endpoints = await build();
             await zip();


### PR DESCRIPTION
The flag `--retainVersion` can be used on the `upload` and `deploy` commands to disable automatic version incrementation.
This is useful if versions are managed externally