### PR TITLE
Added experimental support for `exposedApi` command that generates types for consumers

### DIFF
--- a/src/Commands/Commands.ts
+++ b/src/Commands/Commands.ts
@@ -10,6 +10,11 @@ export const enum Commands {
     declarations = 'declarations',
 
     /**
+     * The declarations command that builds the thingworx collection declarations.
+     */
+    exposedApi = 'exposedApi',
+
+    /**
      * The watch command that monitors files and triggers the declarations command whenever
      * anything changes.
      */

--- a/src/Scripts/generateApiDeclarations.ts
+++ b/src/Scripts/generateApiDeclarations.ts
@@ -1,0 +1,45 @@
+import { TWThingTransformerFactory, TWConfig } from 'bm-thing-transformer';
+import * as fs from 'fs';
+import { TSUtilities } from '../Utilities/TSUtilities';
+
+/**
+ * Builds the thingworx collection declarations of the thingworx project.
+ */
+export function exposedApi() {
+
+    const cwd = process.cwd();
+    // Load the twconfig file which contains complication options.
+    const twConfig = require(`${cwd}/twconfig.json`) as TWConfig;
+
+    process.stdout.write(`\x1b[1;31m✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖\x1b[0m\n`);
+    process.stdout.write(`\x1b[1;31m✖✖✖✖✖✖✖\x1b[0m Building exposed APIs is considered experimental and subject to change \x1b[1;31m✖✖✖✖✖✖✖\x1b[0m\n`);
+    process.stdout.write(`\x1b[1;31m✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖✖\x1b[0m\n`);
+
+    process.stdout.write(`\x1b[2m❯\x1b[0m Building exposed API`);
+    
+    // Create a new store for each project
+    twConfig.store = {};
+
+    // Create the typescript project and emit using a "watch" transformer
+    const program = TSUtilities.programWithPath(cwd);
+    program.emit(undefined, () => {}, undefined, undefined, {
+        before: [
+            TWThingTransformerFactory(program, cwd, false, false, twConfig)
+        ],
+    });
+
+    // Accumulate the declarations into a single file
+    let declarations = "import { ServiceResult, INFOTABLE, NOTHING, NUMBER, STRING, INTEGER } from './global';\n";
+    
+    for (const key in twConfig.store) {
+        if (key == '@globalBlocks') continue;
+        const entity = twConfig.store[key];
+        declarations += `\n${entity.toApiDeclaration()}\n`;
+    }
+
+    // Write the declarations to a .d.ts file
+    TSUtilities.ensurePath(`${cwd}/api`, cwd);
+    fs.writeFileSync(`${cwd}/api/Generated.d.ts`, declarations);
+
+    process.stdout.write(`\r\x1b[1;32m✔\x1b[0m Built exposed API  \n`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { addProject } from './Scripts/add-project';
 import { install } from './Scripts/install';
 import { init } from './Scripts/init';
 import { upgrade } from './Scripts/upgrade';
+import { exposedApi } from './Scripts/generateApiDeclarations';
 import * as fs from 'fs';
 import * as dotenv from 'dotenv';
 
@@ -84,6 +85,9 @@ async function main() {
             break;
         case Commands.upgrade:
             await upgrade();
+            break;
+        case Commands.exposedApi:
+            await exposedApi();
             break;
         default:
             console.error(`Unknown command "${command}" specified.`);


### PR DESCRIPTION
Requires https://github.com/BogdanMihaiciuc/ThingTransformer/pull/24. See it's task list,

Currently the command outputs a big warning highlighting it's still subject to change.
