### PR TITLE
Fix watch loop in multiproject repos with helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ async function main() {
 
                 // Don't process this if it's a change to the static directory, which is generated
                 // by the declarations command
-                if (filename.match(/(.*)[\/\\]static[\/\\]gen[\/\\]Generated\.d\.ts$/)) return;
+                if (filename.match(/(.*)[\/\\]?static[\/\\]gen[\/\\]Generated\.d\.ts$/)) return;
 
                 // In certain cases the callback is invoked twice, so wait for a short while before running to avoid this
                 declarationsRunning = true;


### PR DESCRIPTION
The file `Generated.d.ts` in the root directory comes without an initial slash `'static/gen/Generated.d.ts'` so the regex fails.

Make the initial slash optional