### PR TITLE
Fix missing comma in import statement

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+Resolves an issue that broke the `generate-api` command.
+
 # 1.3.1
 
 Updates to thing transformer 1.3.1 which resolves an issue where inline SQL statements would compile into code with syntax errors.

--- a/src/Scripts/generate-api.ts
+++ b/src/Scripts/generate-api.ts
@@ -30,7 +30,7 @@ export function generateAPI() {
     }
 
     // Accumulate the declarations into a single file
-    let declarations = "import { ServiceResult, DATETIME, JSON INFOTABLE, NOTHING, NUMBER, STRING, INTEGER, BOOLEAN, TWJSON, LOCATION, IMAGE, HYPERLINK, PASSWORD, TEXT, HTML, GUID, BLOB, LONG, THINGNAME } from './global';\n";
+    let declarations = "import { ServiceResult, DATETIME, JSON, INFOTABLE, NOTHING, NUMBER, STRING, INTEGER, BOOLEAN, TWJSON, LOCATION, IMAGE, HYPERLINK, PASSWORD, TEXT, HTML, GUID, BLOB, LONG, THINGNAME } from './global';\n";
     let runtime = "const DataShapesDefinitions = { ";
     
     for (const key in twConfig.store) {


### PR DESCRIPTION
Resolves a missing comma in the import statement of the file generated by the `generate-api` command.