### PR TITLE
Upload extension support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# 1.5.1
+
+The `upload` command can now take an additional argument `--extensions` that, when specified, causes the command to also upload any extensions in the `extensions` directory in the root of the project to the thingworx server before uploading the project extension.
+
+When specifying the `@deploy` decorator on thing templates or thing shapes, the deploy command will now invoke the relevant services on things that derive from them.
+
+When `@deploy` services return a single value, these values will now be printed out.
+
 # 1.5
 
 The `--uml` argument is now deprecated for the `install` command and will print out a warning when used.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "bm-thing-cli",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "bm-thing-cli",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "0.5.9",
-                "bm-thing-transformer": "1.5.0",
+                "bm-thing-transformer": "1.5.1",
                 "dotenv": "^16.0.0",
                 "enquirer": "^2.3.6",
                 "typescript": "4.6.3",
@@ -56,9 +56,9 @@
             }
         },
         "node_modules/bm-thing-transformer": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.5.0.tgz",
-            "integrity": "sha512-5UQgtkLg3MUpm8057iCk7Jt9Y9O/CuQ+4VX+9Hsn7qvT9CR2l9e5iDN5CnSOZIFv7UEvkvBKrCk3Bl3RbW2waw==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.5.1.tgz",
+            "integrity": "sha512-kgCcVkrx8oJDIQlOSIVQQAqZSB5j6g6ATBq3o/VipofpVeJctqN9iHTCAZ8iRM2kVdCKaItGvBxG/06j+JfZnA==",
             "dependencies": {
                 "typescript": "4.6.3",
                 "xml2js": "^0.4.23"
@@ -148,9 +148,9 @@
             "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
         },
         "bm-thing-transformer": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.5.0.tgz",
-            "integrity": "sha512-5UQgtkLg3MUpm8057iCk7Jt9Y9O/CuQ+4VX+9Hsn7qvT9CR2l9e5iDN5CnSOZIFv7UEvkvBKrCk3Bl3RbW2waw==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.5.1.tgz",
+            "integrity": "sha512-kgCcVkrx8oJDIQlOSIVQQAqZSB5j6g6ATBq3o/VipofpVeJctqN9iHTCAZ8iRM2kVdCKaItGvBxG/06j+JfZnA==",
             "requires": {
                 "typescript": "4.6.3",
                 "xml2js": "^0.4.23"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-cli",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "Command line tools for the Thingworx VSCode Project",
     "bin": {
         "twc": "dist/index.js"
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "adm-zip": "0.5.9",
-        "bm-thing-transformer": "1.5.0",
+        "bm-thing-transformer": "1.5.1",
         "dotenv": "^16.0.0",
         "enquirer": "^2.3.6",
         "typescript": "4.6.3",

--- a/src/Scripts/add-project.ts
+++ b/src/Scripts/add-project.ts
@@ -1,5 +1,5 @@
 import Enquirer from "enquirer";
-import * as fs from 'fs';
+import * as FS from 'fs';
 import { TWConfig } from 'bm-thing-transformer';
 import { TSUtilities } from "../Utilities/TSUtilities";
 
@@ -45,21 +45,21 @@ export async function addProject(): Promise<void> {
 
         // Copy the contents of the src folder into a subfolder with the current project name
         // First copy to a temporary folder, then clear out the contents of src
-        fs.cpSync(`${cwd}/src`, `${cwd}/tmp`, {recursive: true});
-        fs.rmSync(`${cwd}/src`, {recursive: true, force: true});
+        FS.cpSync(`${cwd}/src`, `${cwd}/tmp`, {recursive: true});
+        FS.rmSync(`${cwd}/src`, {recursive: true, force: true});
 
         // Then copy into the appropriate subfolder in src and clear the temporary folder
         TSUtilities.ensurePath(`${cwd}/src/${projectName}/src`, cwd);
-        fs.cpSync(`${cwd}/tmp`, `${cwd}/src/${projectName}/src`, {recursive: true});
-        fs.rmSync(`${cwd}/tmp`, {recursive: true, force: true});
+        FS.cpSync(`${cwd}/tmp`, `${cwd}/src/${projectName}/src`, {recursive: true});
+        FS.rmSync(`${cwd}/tmp`, {recursive: true, force: true});
 
         // Create and save a default tsconfig.json file
         const tsConfig = JSON.stringify(tsConfigDefault(), undefined, 4);
-        fs.writeFileSync(`${cwd}/src/${projectName}/tsconfig.json`, tsConfig);
+        FS.writeFileSync(`${cwd}/src/${projectName}/tsconfig.json`, tsConfig);
 
         // Set the twconfig project name to '@auto' then save it
         twConfig.projectName = '@auto';
-        fs.writeFileSync(`${cwd}/twconfig.json`, JSON.stringify(twConfig, undefined, 4));
+        FS.writeFileSync(`${cwd}/twconfig.json`, JSON.stringify(twConfig, undefined, 4));
 
         process.stdout.write(`\r\x1b[1;32m✔\x1b[0m Converted to multi-project   \n`);
     }
@@ -78,14 +78,14 @@ export async function addProject(): Promise<void> {
     process.stdout.write(`\x1b[2m❯\x1b[0m Creating project "${name}"`);
 
     // Create a folder in the src directory for this project
-    fs.mkdirSync(`${cwd}/src/${name}`);
+    FS.mkdirSync(`${cwd}/src/${name}`);
 
     // Add the default tsconfig file
     const tsConfig = JSON.stringify(tsConfigDefault(), undefined, 4);
-    fs.writeFileSync(`${cwd}/src/${name}/tsconfig.json`, tsConfig);
+    FS.writeFileSync(`${cwd}/src/${name}/tsconfig.json`, tsConfig);
 
     // Create a src directory for the project
-    fs.mkdirSync(`${cwd}/src/${name}/src`);
+    FS.mkdirSync(`${cwd}/src/${name}/src`);
 
     process.stdout.write(`\r\x1b[1;32m✔\x1b[0m Created project "${name}"  \n`);
 }

--- a/src/Scripts/build.ts
+++ b/src/Scripts/build.ts
@@ -1,6 +1,6 @@
-import { TWThingTransformerFactory, TWConfig, TWThingTransformer, DiagnosticMessageKind, DiagnosticMessage } from 'bm-thing-transformer';
+import { TWThingTransformerFactory, TWConfig, TWThingTransformer, DiagnosticMessageKind, DiagnosticMessage, DeploymentEndpoint } from 'bm-thing-transformer';
 import { randomUUID } from 'crypto';
-import * as fs from 'fs';
+import * as FS from 'fs';
 import * as Path from 'path';
 import { Builder, parseStringPromise } from 'xml2js';
 import { TSUtilities } from '../Utilities/TSUtilities';
@@ -14,11 +14,11 @@ const [path, bin, command, ...args] = process.argv;
  * @returns             A promise that resolves with an array of deployment
  *                      endpoints when the operation completes.
  */
-export async function build(): Promise<string[]> {
+export async function build(): Promise<DeploymentEndpoint[]> {
     const cwd = process.cwd();
 
     // The array of deployment endpoints discovered while building
-    const deploymentEndpoints: string[] = [];
+    const deploymentEndpoints: DeploymentEndpoint[] = [];
 
     // Load the twconfig file which contains compilation options.
     const twConfig = require(`${process.cwd()}/twconfig.json`) as TWConfig;
@@ -44,8 +44,8 @@ export async function build(): Promise<string[]> {
     twConfig.trace = isTraceBuild;
 
     // Clear the build output folder to remove any entities which may have been removed from the project
-    if (fs.existsSync(`${cwd}/build`)) {
-        fs.rmSync(`${cwd}/build`, {force: true, recursive: true});
+    if (FS.existsSync(`${cwd}/build`)) {
+        FS.rmSync(`${cwd}/build`, {force: true, recursive: true});
     }
 
     if (twConfig.projectName == '@auto') {
@@ -53,7 +53,7 @@ export async function build(): Promise<string[]> {
         const baseOutPath = `${cwd}/build`;
 
         // Before starting a build, ensure that the base out path exists
-        if (!fs.existsSync(baseOutPath)) fs.mkdirSync(baseOutPath)
+        if (!FS.existsSync(baseOutPath)) FS.mkdirSync(baseOutPath)
 
         for (const p of TSUtilities.projects()) {
             // For merged builds, everything ends up in the same extension while for
@@ -76,8 +76,8 @@ export async function build(): Promise<string[]> {
      */
     async function buildProject(projectName: string, path: string, outPath: string): Promise<void> {
         // Ensure the outpath exists
-        if (!fs.existsSync(outPath)) {
-            fs.mkdirSync(outPath);
+        if (!FS.existsSync(outPath)) {
+            FS.mkdirSync(outPath);
         }
 
         // Create a new store for each project
@@ -86,7 +86,7 @@ export async function build(): Promise<string[]> {
         process.stdout.write(`\x1b[2m❯\x1b[0m Building ${projectName || 'project'}`);
 
         let tsConfig: any;
-        if (fs.existsSync(`${path}/tsconfig.json`)) {
+        if (FS.existsSync(`${path}/tsconfig.json`)) {
             tsConfig = require(`${path}/tsconfig.json`);
         }
 
@@ -211,7 +211,7 @@ export async function build(): Promise<string[]> {
 
             // Write the debug entity in the appropriate subfolder
             TSUtilities.ensurePath(`${outPath}/Entities/Projects`, outPath);
-            fs.writeFileSync(`${outPath}/Entities/Projects/${projectName}.xml`, projectEntity);
+            FS.writeFileSync(`${outPath}/Entities/Projects/${projectName}.xml`, projectEntity);
         }
 
         // If this is a debug build, create a notifier thing that informs the debugger runtime that new source files are available
@@ -222,12 +222,12 @@ export async function build(): Promise<string[]> {
             
             // Write the debug entity in the appropriate subfolder
             TSUtilities.ensurePath(`${outPath}/Entities/Things`, outPath);
-            fs.writeFileSync(`${outPath}/Entities/Things/${debugEntityName}.xml`, debugEntity);
+            FS.writeFileSync(`${outPath}/Entities/Things/${debugEntityName}.xml`, debugEntity);
         }
 
 
         // Copy and update the metadata file
-        const metadataFile = fs.readFileSync(`${process.cwd()}/metadata.xml`, 'utf8');
+        const metadataFile = FS.readFileSync(`${process.cwd()}/metadata.xml`, 'utf8');
         const metadataXML = await parseStringPromise(metadataFile);
 
         // In multi project mode, for separate builds, append the project name to the package name
@@ -250,7 +250,7 @@ export async function build(): Promise<string[]> {
         const builder = new Builder();
         const outXML = builder.buildObject(metadataXML);
 
-        fs.writeFileSync(`${outPath}/metadata.xml`, outXML);
+        FS.writeFileSync(`${outPath}/metadata.xml`, outXML);
 
         const timeEnd = process.hrtime();
         const duration = (timeEnd[0] + timeEnd[1] / 1_000_000_000 - timeStart[0] - timeStart[1] / 1_000_000_000)
@@ -278,19 +278,19 @@ export async function build(): Promise<string[]> {
              */
             function copyXMLFilesInDirectory(path: string): void {
                 // Get all files in the directory
-                const files = fs.readdirSync(path);
+                const files = FS.readdirSync(path);
 
                 for (const file of files) {
                     const filePath = Path.join(path, file);
                     // Recursively look into subdirectories
-                    if (fs.statSync(filePath).isDirectory()) {
+                    if (FS.statSync(filePath).isDirectory()) {
                         copyXMLFilesInDirectory(filePath);
                         continue;
                     }
 
                     // If the file is an xml, copy it to the build directory
                     if (file.toLowerCase().endsWith('.xml')) {
-                        fs.cpSync(filePath, `${outPath}/Entities/${file}`);
+                        FS.cpSync(filePath, `${outPath}/Entities/${file}`);
                     }
                 }
             }

--- a/src/Scripts/declarations.ts
+++ b/src/Scripts/declarations.ts
@@ -1,5 +1,5 @@
 import { TWThingTransformerFactory, TWConfig } from 'bm-thing-transformer';
-import * as fs from 'fs';
+import * as FS from 'fs';
 import * as ts from 'typescript';
 import { TSUtilities } from '../Utilities/TSUtilities';
 
@@ -59,14 +59,14 @@ export function declarations() {
 
         // Write the declarations to a .d.ts file
         TSUtilities.ensurePath(`${path}/static/gen`, path);
-        fs.writeFileSync(`${path}/static/gen/Generated.d.ts`, declarations);
+        FS.writeFileSync(`${path}/static/gen/Generated.d.ts`, declarations);
     }
     
     const cwd = process.cwd();
     
     if (twConfig.projectName == '@auto') {
         TSUtilities.ensurePath(`${cwd}/src/static/gen`, cwd);
-        fs.writeFileSync(`${cwd}/src/static/gen/Generated.d.ts`, getMethodHelperDeclarations());
+        FS.writeFileSync(`${cwd}/src/static/gen/Generated.d.ts`, getMethodHelperDeclarations());
         // If running in multi-project mode, run against each project separately
         TSUtilities.projects().forEach(p => {
             emitDeclarationsOfProject(p.path);

--- a/src/Scripts/deploy.ts
+++ b/src/Scripts/deploy.ts
@@ -1,3 +1,4 @@
+import { DeploymentEndpoint, TWEntityKind } from 'bm-thing-transformer/dist/@types';
 import { TWClient } from '../Utilities/TWClient';
 
 /**
@@ -5,22 +6,55 @@ import { TWClient } from '../Utilities/TWClient';
  * @param endpoints         The endpoints to invoke.
  * @returns                 A promise that resolves when this operation finishes.
  */
-export async function deploy(endpoints: string[]): Promise<void> {
+export async function deploy(endpoints: DeploymentEndpoint[]): Promise<void> {
     for (const endpoint of endpoints) {
-        process.stdout.write(`\x1b[2m❯\x1b[0m Running deployment script \x1b[1m${endpoint}\x1b[0m`);
-        try {
-            const response = await TWClient.invokeEndpoint(endpoint);
-            if (response.statusCode != 200) {
-                process.stdout.write(`\r\x1b[1;31m✖\x1b[0m Deployment script \x1b[1m${endpoint}\x1b[0m failed:       \n`);
-                console.log(response.body);
-            }
-            else {
-                process.stdout.write(`\r\x1b[1;32m✔\x1b[0m Deployment script \x1b[1m${endpoint}\x1b[0m ran successfully\n`);
-            }
+        switch (endpoint.kind) {
+            case TWEntityKind.Thing:
+                // For things, invoke the service directly
+                await invokeEndpoint(`Things/${endpoint.name}/Services/${endpoint.service}`);
+                break;
+            case TWEntityKind.ThingTemplate:
+            case TWEntityKind.ThingShape:
+                // For templates and shapes, invoke the service on all things that inherit from it
+                try {
+                    const response = await TWClient.invokeEndpoint(`${endpoint.kind}s/${endpoint.name}/Services/GetImplementingThings`);
+                    if (response.statusCode != 200) {
+                        process.stdout.write(`\x1b[1;31m✖\x1b[0m Deployment script \x1b[1m${endpoint.service}\x1b[0m failed for ${endpoint.kind} ${endpoint.name}: \n`);
+                        console.log(response.body);
+                    }
+                    else {
+                        const result = JSON.parse(response.body);
+                        for (const row of result.rows) {
+                            await invokeEndpoint(`Things/${row.name}/Services/${endpoint.service}`);
+                        }
+                    }
+                }
+                catch (err) {
+                    process.stdout.write(`\x1b[1;31m✖\x1b[0m Deployment script \x1b[1m${endpoint.service}\x1b[0m failed for ${endpoint.kind} ${endpoint.name}: \n`);
+                    console.log(err);
+                }
+                break;
+            default:
+                process.stdout.write(`\x1b[1;31m✖\x1b[0m Skipping unsupported deployment script \x1b[1m${endpoint.service}\x1b[0m for entity kind "${endpoint.kind}". \n`);
+                break;
         }
-        catch (err) {
+    }
+}
+
+async function invokeEndpoint(endpoint: string): Promise<void> {
+    process.stdout.write(`\x1b[2m❯\x1b[0m Running deployment script \x1b[1m${endpoint}\x1b[0m`);
+    try {
+        const response = await TWClient.invokeEndpoint(endpoint);
+        if (response.statusCode != 200) {
             process.stdout.write(`\r\x1b[1;31m✖\x1b[0m Deployment script \x1b[1m${endpoint}\x1b[0m failed:       \n`);
-            console.log(err);
+            console.log(response.body);
         }
+        else {
+            process.stdout.write(`\r\x1b[1;32m✔\x1b[0m Deployment script \x1b[1m${endpoint}\x1b[0m ran successfully\n`);
+        }
+    }
+    catch (err) {
+        process.stdout.write(`\r\x1b[1;31m✖\x1b[0m Deployment script \x1b[1m${endpoint}\x1b[0m failed:       \n`);
+        console.log(err);
     }
 }

--- a/src/Scripts/deploy.ts
+++ b/src/Scripts/deploy.ts
@@ -51,6 +51,16 @@ async function invokeEndpoint(endpoint: string): Promise<void> {
         }
         else {
             process.stdout.write(`\r\x1b[1;32m✔\x1b[0m Deployment script \x1b[1m${endpoint}\x1b[0m ran successfully\n`);
+            try {
+                const result = JSON.parse(response.body);
+
+                if (result.rows && result.rows.length == 1 && result.rows[0].result) {
+                    console.log(`  \x1b[2m❯\x1b[0m ${result.rows[0].result}`);
+                }
+            }
+            catch (err) {
+                // If the response can't be parsed, ignore it
+            }
         }
     }
     catch (err) {

--- a/src/Scripts/generate-api.ts
+++ b/src/Scripts/generate-api.ts
@@ -1,5 +1,5 @@
 import { TWThingTransformerFactory, TWConfig, TWEntityKind } from 'bm-thing-transformer';
-import * as fs from 'fs';
+import * as FS from 'fs';
 import * as ts from 'typescript';
 import { TSUtilities } from '../Utilities/TSUtilities';
 import { APIGenerator } from '../Utilities/APIDeclarationGenerator';
@@ -100,8 +100,8 @@ export function generateAPI() {
 
     // Write the declarations to a .d.ts file
     TSUtilities.ensurePath(`${cwd}/api`, cwd);
-    fs.writeFileSync(`${cwd}/api/Generated.d.ts`, declarations);
-    fs.writeFileSync(`${cwd}/api/Runtime.ts`, runtime);
+    FS.writeFileSync(`${cwd}/api/Generated.d.ts`, declarations);
+    FS.writeFileSync(`${cwd}/api/Runtime.ts`, runtime);
 
     process.stdout.write(`\r\x1b[1;32m✔\x1b[0m Built exported API   \n`);
 }

--- a/src/Scripts/increment-version.ts
+++ b/src/Scripts/increment-version.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as FS from 'fs';
 
 /**
  * Increments the minor version declared in package.json by 1.
@@ -19,7 +19,7 @@ export function incrementVersion(): void {
     
     packageJSON.version = version.join('-');
 
-    fs.writeFileSync(`${cwd}/package.json`, JSON.stringify(packageJSON, undefined, '\t'));
+    FS.writeFileSync(`${cwd}/package.json`, JSON.stringify(packageJSON, undefined, '\t'));
 
     console.log(`\x1b[1;32m✔\x1b[0m Incremented version to ${packageJSON.version}`);
 }

--- a/src/Scripts/init.ts
+++ b/src/Scripts/init.ts
@@ -1,5 +1,5 @@
 import Enquirer from "enquirer";
-import * as fs from 'fs';
+import * as FS from 'fs';
 import { TWConfig, MethodHelpers } from 'bm-thing-transformer';
 import { URL } from "url";
 import { spawn } from 'child_process';
@@ -198,22 +198,22 @@ export async function init() {
     const creationParameters: CreationParameters = Object.assign({}, baseDetails, authenticationDetails);
 
     // Create the necessary files
-    fs.writeFileSync(`${cwd}/package.json`, JSON.stringify(packageDefault(creationParameters), undefined, 4));
-    fs.writeFileSync(`${cwd}/tsconfig.json`, JSON.stringify(tsConfigDefault(), undefined, 4));
-    fs.writeFileSync(`${cwd}/twconfig.json`, JSON.stringify(twConfigDefault(creationParameters.projectName), undefined, 4));
-    fs.writeFileSync(`${cwd}/metadata.xml`, metadataXMLDefault());
-    fs.writeFileSync(`${cwd}/.gitignore`, gitignoreDefault());
+    FS.writeFileSync(`${cwd}/package.json`, JSON.stringify(packageDefault(creationParameters), undefined, 4));
+    FS.writeFileSync(`${cwd}/tsconfig.json`, JSON.stringify(tsConfigDefault(), undefined, 4));
+    FS.writeFileSync(`${cwd}/twconfig.json`, JSON.stringify(twConfigDefault(creationParameters.projectName), undefined, 4));
+    FS.writeFileSync(`${cwd}/metadata.xml`, metadataXMLDefault());
+    FS.writeFileSync(`${cwd}/.gitignore`, gitignoreDefault());
 
-    fs.mkdirSync(`${cwd}/src`);
+    FS.mkdirSync(`${cwd}/src`);
 
     // Create an env file with the authentication details
     if (creationParameters.thingworxServer) {
-        fs.writeFileSync(`${cwd}/.env`, envDefault(creationParameters));
+        FS.writeFileSync(`${cwd}/.env`, envDefault(creationParameters));
 
         // If an app key authentication was selected, create an attach launch configuration
         if ('thingworxAppKey' in creationParameters) {
-            fs.mkdirSync(`${cwd}/.vscode`);
-            fs.writeFileSync(`${cwd}/.vscode/launch.json`, JSON.stringify(launchConfigurationDefault(creationParameters), undefined, 4));
+            FS.mkdirSync(`${cwd}/.vscode`);
+            FS.writeFileSync(`${cwd}/.vscode/launch.json`, JSON.stringify(launchConfigurationDefault(creationParameters), undefined, 4));
         }
     }
 
@@ -238,7 +238,7 @@ function projectExists(path: string): boolean {
     // - metadata.xml:      thingworx metadata template
     // - src:               the sources folder
 
-    if (fs.existsSync(`${path}/package.json`)) {
+    if (FS.existsSync(`${path}/package.json`)) {
         // For this to be a thingworx project, it needs to have bm-thing-cli as a dev dependency.
         const packageJSON = require(`${path}/package.json`);
         const devDependencies = packageJSON.devDependencies;
@@ -256,12 +256,12 @@ function projectExists(path: string): boolean {
 
     // Most of the options in tsconfig are optional for this project, the default ones are just recommendations
     // so its only required that such a file exists
-    if (!fs.existsSync(`${path}/tsconfig.json`)) {
+    if (!FS.existsSync(`${path}/tsconfig.json`)) {
         return false;
     }
 
     // A twconfig.json file must exist and contain at least the "projectName" key
-    if (!fs.existsSync(`${path}/twconfig.json`)) {
+    if (!FS.existsSync(`${path}/twconfig.json`)) {
         return false;
     }
     else {
@@ -272,7 +272,7 @@ function projectExists(path: string): boolean {
     }
 
     // A template metadata file must exist
-    if (!fs.existsSync(`${path}/metadata.xml`)) {
+    if (!FS.existsSync(`${path}/metadata.xml`)) {
         return false;
     }
 

--- a/src/Scripts/install.ts
+++ b/src/Scripts/install.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as FS from 'fs';
 import { TWConfig } from 'bm-thing-transformer';
 import { TWClient } from '../Utilities/TWClient';
 import { GenericThingPackages, NonAlphanumericRegexGlobal, TWMetadataParser } from '../Utilities/TWMetadataParser';
@@ -133,8 +133,8 @@ export async function install(isUMLMode: boolean = false) {
         }
 
         // Delete and fully recreate the tw_imports folder
-        fs.rmSync(`${cwd}/tw_imports`, {recursive: true, force: true});
-        fs.mkdirSync(`${cwd}/tw_imports`);
+        FS.rmSync(`${cwd}/tw_imports`, {recursive: true, force: true});
+        FS.mkdirSync(`${cwd}/tw_imports`);
 
         for (const extension of (twConfig.extensionDependencies || [])) {
             const slice = 1 / totalPackages;
@@ -298,14 +298,14 @@ async function getEntityDependencies(name, kind): Promise<JSONInfoTable<EntityDe
 
     const body = JSON.parse(response.body);
     // Add the declaration for this project
-    if (!fs.existsSync('./tw_imports/Projects/')) {
-        fs.mkdirSync('./tw_imports/Projects/');
+    if (!FS.existsSync('./tw_imports/Projects/')) {
+        FS.mkdirSync('./tw_imports/Projects/');
     }
 
     installedEntities.Projects = installedEntities.Projects || {};
     installedEntities.Projects[name] = true;
 
-    fs.writeFileSync(`./tw_imports/Projects/${name}.d.ts`, `declare interface Projects { ${JSON.stringify(name)}: ProjectEntity; }`)
+    FS.writeFileSync(`./tw_imports/Projects/${name}.d.ts`, `declare interface Projects { ${JSON.stringify(name)}: ProjectEntity; }`)
 
     return body;
 }
@@ -344,14 +344,14 @@ async function getExtension(name: string, slice: number, installProgress: Instal
         // If the typings exist, write the .d.ts file directly.
         const definition = typesResponse.body;
 
-        if (!fs.existsSync(`./tw_imports/Extensions/`)) {
-            fs.mkdirSync(`./tw_imports/Extensions/`);
+        if (!FS.existsSync(`./tw_imports/Extensions/`)) {
+            FS.mkdirSync(`./tw_imports/Extensions/`);
         }
     
         installedEntities.Extensions = installedEntities.Extensions || {};
         installedEntities.Extensions[name] = true;
     
-        fs.writeFileSync(`./tw_imports/Extensions/${name}.d.ts`, definition);
+        FS.writeFileSync(`./tw_imports/Extensions/${name}.d.ts`, definition);
 
         installProgress.progress += slice / 2;
     }
@@ -403,14 +403,14 @@ function importThing(body: any, withInterface = true): void {
     const declaration = parser.declarationOfThing(body);
 
     // Write out the thing
-    if (!fs.existsSync(`./tw_imports/Things/`)) {
-        fs.mkdirSync(`./tw_imports/Things/`);
+    if (!FS.existsSync(`./tw_imports/Things/`)) {
+        FS.mkdirSync(`./tw_imports/Things/`);
     }
 
     installedEntities.Things = installedEntities.Things || {};
     installedEntities.Things[name] = true;
 
-    fs.writeFileSync(`./tw_imports/Things/${name}.d.ts`, `/**
+    FS.writeFileSync(`./tw_imports/Things/${name}.d.ts`, `/**
  * @module ${body.projectName}
  */
 /**
@@ -438,14 +438,14 @@ function importThingTemplate(body: any, withInterface = true): void {
     const hasGenericArgument = GenericThingPackages.includes(body.effectiveThingPackage);
 
     // Write out the thing template
-    if (!fs.existsSync(`./tw_imports/ThingTemplates/`)) {
-        fs.mkdirSync(`./tw_imports/ThingTemplates/`);
+    if (!FS.existsSync(`./tw_imports/ThingTemplates/`)) {
+        FS.mkdirSync(`./tw_imports/ThingTemplates/`);
     }
 
     installedEntities.ThingTemplates = installedEntities.ThingTemplates || {};
     installedEntities.ThingTemplates[name] = true;
 
-    fs.writeFileSync(`./tw_imports/ThingTemplates/${name}.d.ts`, `/**
+    FS.writeFileSync(`./tw_imports/ThingTemplates/${name}.d.ts`, `/**
  * @module ${body.projectName}
  */
 /**
@@ -473,14 +473,14 @@ function importThingShape(body: any, withInterface = true): void {
     const declaration = parser.declarationOfThingShape(body);
 
     // Write out the thing shape
-    if (!fs.existsSync(`./tw_imports/ThingShapes/`)) {
-        fs.mkdirSync(`./tw_imports/ThingShapes/`);
+    if (!FS.existsSync(`./tw_imports/ThingShapes/`)) {
+        FS.mkdirSync(`./tw_imports/ThingShapes/`);
     }
 
     installedEntities.ThingShapes = installedEntities.ThingShapes || {};
     installedEntities.ThingShapes[name] = true;
 
-    fs.writeFileSync(`./tw_imports/ThingShapes/${name}.d.ts`, `/**
+    FS.writeFileSync(`./tw_imports/ThingShapes/${name}.d.ts`, `/**
  * @module ${body.projectName}
  */
 /**
@@ -508,14 +508,14 @@ function importDataShape(body: any, withInterface = true): void {
     const declaration = parser.declarationOfDataShape(body);
 
     // Write out the data shape
-    if (!fs.existsSync(`./tw_imports/DataShapes/`)) {
-        fs.mkdirSync(`./tw_imports/DataShapes/`);
+    if (!FS.existsSync(`./tw_imports/DataShapes/`)) {
+        FS.mkdirSync(`./tw_imports/DataShapes/`);
     }
 
     installedEntities.DataShapes = installedEntities.DataShapes || {};
     installedEntities.DataShapes[name] = true;
 
-    fs.writeFileSync(`./tw_imports/DataShapes/${name}.d.ts`, `/**
+    FS.writeFileSync(`./tw_imports/DataShapes/${name}.d.ts`, `/**
  * @module ${body.projectName}
  */
 /**
@@ -541,14 +541,14 @@ function importResource(body: any, withInterface = true): void {
     let declaration = parser.declarationOfResource(body);
 
     // Write out the resource
-    if (!fs.existsSync(`./tw_imports/Resources/`)) {
-        fs.mkdirSync(`./tw_imports/Resources/`);
+    if (!FS.existsSync(`./tw_imports/Resources/`)) {
+        FS.mkdirSync(`./tw_imports/Resources/`);
     }
 
     installedEntities.Resources = installedEntities.Resources || {};
     installedEntities.Resources[name] = true;
 
-    fs.writeFileSync(`./tw_imports/Resources/${name}.d.ts`, `/**
+    FS.writeFileSync(`./tw_imports/Resources/${name}.d.ts`, `/**
  * @module ${body.projectName}
  */
 /**
@@ -602,8 +602,8 @@ function importMashup(body: any, withInterface = true): void {
     let declaration = parser.declarationOfMashup(body);
 
     // Write out the resource
-    if (!fs.existsSync(`./tw_imports/Mashups/`)) {
-        fs.mkdirSync(`./tw_imports/Mashups/`);
+    if (!FS.existsSync(`./tw_imports/Mashups/`)) {
+        FS.mkdirSync(`./tw_imports/Mashups/`);
     }
 
     installedEntities.Mashups = installedEntities.Mashups || {};
@@ -611,7 +611,7 @@ function importMashup(body: any, withInterface = true): void {
 
     if (UMLMode) {
         // In UML mode write the mashup class
-        fs.writeFileSync(`./tw_imports/Mashups/${name}.d.ts`, `/**
+        FS.writeFileSync(`./tw_imports/Mashups/${name}.d.ts`, `/**
  * @module ${body.projectName}
  */
 /**
@@ -627,7 +627,7 @@ ${declaration}${withInterface ? `\n\ndeclare interface Mashups {
     }
     else {
         // In non-UML mode, write just the interface declaration
-        fs.writeFileSync(`./tw_imports/Mashups/${name}.d.ts`, withInterface ? `/**
+        FS.writeFileSync(`./tw_imports/Mashups/${name}.d.ts`, withInterface ? `/**
  * @module ${body.projectName}
  */
 /**
@@ -655,14 +655,14 @@ declare interface Mashups {
  * @param body              The entity metadata.
  */
 function importEntityDeclaration(name: string, kind: string, description: string, genericArgument?: string, withInterface = true, body?: any): void {
-    if (!fs.existsSync(`./tw_imports/${kind}/`)) {
-        fs.mkdirSync(`./tw_imports/${kind}/`);
+    if (!FS.existsSync(`./tw_imports/${kind}/`)) {
+        FS.mkdirSync(`./tw_imports/${kind}/`);
     }
 
     installedEntities[kind] = installedEntities[kind] || {};
     installedEntities[kind][name] = true;
 
-    fs.writeFileSync(`./tw_imports/${kind}/${name}.d.ts`, withInterface ? `/**
+    FS.writeFileSync(`./tw_imports/${kind}/${name}.d.ts`, withInterface ? `/**
  * @module ${body?.projectName}
  */
 declare interface ${kind} { 

--- a/src/Scripts/upgrade.ts
+++ b/src/Scripts/upgrade.ts
@@ -1,5 +1,5 @@
 import Enquirer from 'enquirer';
-import * as fs from 'fs';
+import * as FS from 'fs';
 import { spawn } from 'child_process';
 import { twConfigDefault, twConfigMethodHelperDefaults } from './init';
 
@@ -43,7 +43,7 @@ export async function upgrade() {
     }
 
     // Older projects did not use a twconfig file, create one for them if they don't have it
-    const hasTwConfig = fs.existsSync(`${cwd}/twconfig.json`);
+    const hasTwConfig = FS.existsSync(`${cwd}/twconfig.json`);
 
     let projectName: {projectName: string} | undefined;
     if (!hasTwConfig) {
@@ -72,12 +72,12 @@ export async function upgrade() {
 
     // Handle any updates to the twconfig, like extra functionalities
     if (hasTwConfig) {
-        const currentTwConfig = JSON.parse(fs.readFileSync(`${cwd}/twconfig.json`, 'utf-8'));
+        const currentTwConfig = JSON.parse(FS.readFileSync(`${cwd}/twconfig.json`, 'utf-8'));
         // Add the method helpers options
         if(!currentTwConfig.methodHelpers) {
             currentTwConfig.methodHelpers = twConfigMethodHelperDefaults();
         }
-        fs.writeFileSync(`${cwd}/twconfig.json`, JSON.stringify(currentTwConfig, undefined, 4));
+        FS.writeFileSync(`${cwd}/twconfig.json`, JSON.stringify(currentTwConfig, undefined, 4));
     }
 
     // Add the new thingworx types directories to tsconfig
@@ -93,17 +93,17 @@ export async function upgrade() {
         "./node_modules/bm-thing-transformer/static/**/*.d.ts",
         "./node_modules/bm-thing-cli/node_modules/bm-thing-transformer/static/**/*.d.ts"
     );
-    fs.writeFileSync(`${cwd}/tsconfig.json`, JSON.stringify(tsConfig, undefined, 4));
+    FS.writeFileSync(`${cwd}/tsconfig.json`, JSON.stringify(tsConfig, undefined, 4));
 
     // Remove the gulpfile, since building is now handled by bm-thing-cli
-    fs.rmSync(`${cwd}/gulpfile.js`);
+    FS.rmSync(`${cwd}/gulpfile.js`);
 
     // Remove the static base directory, since dependencies are now included in bm-thing-transformer
-    fs.rmSync(`${cwd}/static/base`, {force: true, recursive: true});
+    FS.rmSync(`${cwd}/static/base`, {force: true, recursive: true});
 
     // If a twconfig file was not used, create it
     if (projectName) {
-        fs.writeFileSync(`${cwd}/twconfig.json`, JSON.stringify(twConfigDefault(projectName.projectName), undefined, 4));
+        FS.writeFileSync(`${cwd}/twconfig.json`, JSON.stringify(twConfigDefault(projectName.projectName), undefined, 4));
     }
 
     // Update the build commands in package json, unless they have been modified
@@ -132,7 +132,7 @@ export async function upgrade() {
     scripts['watch:declarations'] = 'twc watch';
 
     // Write the updated package json
-    fs.writeFileSync(`${cwd}/package.json`, JSON.stringify(packageJSON, undefined, 4));
+    FS.writeFileSync(`${cwd}/package.json`, JSON.stringify(packageJSON, undefined, 4));
 
     // Uninstall all the dependencies that were used by the build script
     await new Promise((resolve, reject) => {
@@ -174,7 +174,7 @@ function formattedDependenciesToRemove(): string {
     // - metadata.xml:      thingworx metadata template
     // - src:               the sources folder
 
-    if (fs.existsSync(`${path}/package.json`)) {
+    if (FS.existsSync(`${path}/package.json`)) {
         // For this to be a gulp based thingworx project, it needs to have gulp as a dev dependency.
         const packageJSON = require(`${path}/package.json`);
         const devDependencies = packageJSON.devDependencies;
@@ -192,17 +192,17 @@ function formattedDependenciesToRemove(): string {
 
     // Most of the options in tsconfig are optional for this project, the default ones are just recommendations
     // so its only required that such a file exists
-    if (!fs.existsSync(`${path}/tsconfig.json`)) {
+    if (!FS.existsSync(`${path}/tsconfig.json`)) {
         return false;
     }
 
     // A template metadata file must exist
-    if (!fs.existsSync(`${path}/metadata.xml`)) {
+    if (!FS.existsSync(`${path}/metadata.xml`)) {
         return false;
     }
 
     // A gulpfile build script must exist
-    if (!fs.existsSync(`${path}/gulpfile.js`)) {
+    if (!FS.existsSync(`${path}/gulpfile.js`)) {
         return false;
     }
 

--- a/src/Scripts/zip.ts
+++ b/src/Scripts/zip.ts
@@ -1,5 +1,5 @@
 import { TWConfig } from 'bm-thing-transformer';
-import * as fs from 'fs';
+import * as FS from 'fs';
 import AdmZip from 'adm-zip';
 import { TSUtilities } from '../Utilities/TSUtilities';
 
@@ -25,11 +25,11 @@ export async function zip(): Promise<void> {
     process.stdout.write(`\x1b[2m❯\x1b[0m Creating extension package`);
 
     // Clear the zip output folder to remove the previous build results
-    if (fs.existsSync(`${cwd}/zip`)) {
-        fs.rmSync(`${cwd}/zip`, {force: true, recursive: true});
+    if (FS.existsSync(`${cwd}/zip`)) {
+        FS.rmSync(`${cwd}/zip`, {force: true, recursive: true});
     }
 
-    fs.mkdirSync(`${cwd}/zip`);
+    FS.mkdirSync(`${cwd}/zip`);
 
     /**
      * Creates a zip archive with the contents of the given path.
@@ -57,7 +57,7 @@ export async function zip(): Promise<void> {
         const baseOutPath = `${cwd}/zip/projects`;
 
         // Ensure that the base out path exists
-        if (!fs.existsSync(baseOutPath)) fs.mkdirSync(baseOutPath)
+        if (!FS.existsSync(baseOutPath)) FS.mkdirSync(baseOutPath)
 
         // Zip each project
         for (const p of TSUtilities.projects()) {
@@ -70,7 +70,7 @@ export async function zip(): Promise<void> {
         // For other commands, it is necessary to keep the zips separate and import them in the appropriate order
         if (command == 'build') {
             await zipPath(zipName, baseOutPath, `${cwd}/zip`);
-            fs.rmSync(baseOutPath, {recursive: true, force: true});
+            FS.rmSync(baseOutPath, {recursive: true, force: true});
         }
     }
     else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,14 +108,33 @@ else {
 bm-thing-cli <command> [--argument] ...
 
 Available commands:
- * \x1b[1mdeclarations\x1b[0m                                                            Builds the collection declarations
- * \x1b[1mwatch\x1b[0m                                                                   Watches the source folder and runs declarations on any change
- * \x1b[1mbuild\x1b[0m [--merged] [--separate] [--debug]                                 Builds the thingworx extension
- * \x1b[1mupload\x1b[0m [--merged] [--separate] [--debug] [--remove] [--retain-version]  Builds and uploads the thingworx extension
- * \x1b[1mdeploy\x1b[0m [--merged] [--separate] [--debug] [--remove] [--retain-version]  Uploads the extension then runs deployment scripts
- * \x1b[1mremove\x1b[0m [--merged] [--separate]                                          Removes the thingworx extension
- * \x1b[1madd-project\x1b[0m                                                             Adds a new project to the repository
- * \x1b[1mgenerate-api\x1b[0m                                                            EXPERIMENTAL: Builds declarations out of exported entities that can be used in other projects
- * \x1b[1minit\x1b[0m                                                                    Initializes a thingworx project in an empty folder
- * \x1b[1mupgrade\x1b[0m                                                                 Upgrades from a gulp project to a twc project`);
+ * \x1b[1mdeclarations\x1b[0m
+   Builds the collection declarations
+
+ * \x1b[1mwatch\x1b[0m
+   Watches the source folder and runs declarations on any change
+
+ * \x1b[1mbuild\x1b[0m [--merged] [--separate] [--debug] [--trace]
+   Builds the thingworx extension
+
+ * \x1b[1mupload\x1b[0m [--merged] [--separate] [--debug] [--trace] [--extensions] [--remove] [--retain-version]
+   Builds and uploads the thingworx extension
+
+ * \x1b[1mdeploy\x1b[0m [--merged] [--separate] [--debug] [--trace] [--extensions] [--remove] [--retain-version]
+   Uploads the extension then runs deployment scripts
+
+ * \x1b[1mremove\x1b[0m [--merged] [--separate]
+   Removes the thingworx extension
+
+ * \x1b[1madd-project\x1b[0m
+   Adds a new project to the repository
+
+ * \x1b[1mgenerate-api\x1b[0m
+   EXPERIMENTAL: Builds declarations out of exported entities that can be used in other projects
+
+ * \x1b[1minit\x1b[0m
+   Initializes a thingworx project in an empty folder
+   
+ * \x1b[1mupgrade\x1b[0m
+   Upgrades from a gulp project to a twc project`);
 }


### PR DESCRIPTION
The `upload` command can now take an additional argument `--extensions` that, when specified, causes the command to also upload any extensions in the `extensions` directory in the root of the project to the thingworx server before uploading the project extension.

When specifying the `@deploy` decorator on thing templates or thing shapes, the deploy command will now invoke the relevant services on things that derive from them.

When `@deploy` services return a single value, these values will now be printed out.