### PR TITLE
1.6

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 1.6
+
+Adds support for specifying which .env file to use. ([stefan-lacatus](https://github.com/stefan-lacatus)) 
+
+Resolves an issue with the `install` command that caused an error to be thrown when attempting to import `Resource` entities.
+
 # 1.5.1
 
 The `upload` command can now take an additional argument `--extensions` that, when specified, causes the command to also upload any extensions in the `extensions` directory in the root of the project to the thingworx server before uploading the project extension.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "bm-thing-cli",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "bm-thing-cli",
-            "version": "1.5.1",
+            "version": "1.6.0",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "0.5.9",
-                "bm-thing-transformer": "1.5.1",
+                "bm-thing-transformer": "1.6.0",
                 "dotenv": "^16.0.0",
                 "enquirer": "^2.3.6",
                 "typescript": "4.6.3",
@@ -56,9 +56,9 @@
             }
         },
         "node_modules/bm-thing-transformer": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.5.1.tgz",
-            "integrity": "sha512-kgCcVkrx8oJDIQlOSIVQQAqZSB5j6g6ATBq3o/VipofpVeJctqN9iHTCAZ8iRM2kVdCKaItGvBxG/06j+JfZnA==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.6.0.tgz",
+            "integrity": "sha512-fqIA0/JdW54puhoesaBDU9jiHdILtL4BPKHQQ/JVqPZmooJaSPieNJ4sRHcooo9oISqGnu3nAqVnDmDTjMTaWQ==",
             "dependencies": {
                 "typescript": "4.6.3",
                 "xml2js": "^0.4.23"
@@ -148,9 +148,9 @@
             "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
         },
         "bm-thing-transformer": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.5.1.tgz",
-            "integrity": "sha512-kgCcVkrx8oJDIQlOSIVQQAqZSB5j6g6ATBq3o/VipofpVeJctqN9iHTCAZ8iRM2kVdCKaItGvBxG/06j+JfZnA==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.6.0.tgz",
+            "integrity": "sha512-fqIA0/JdW54puhoesaBDU9jiHdILtL4BPKHQQ/JVqPZmooJaSPieNJ4sRHcooo9oISqGnu3nAqVnDmDTjMTaWQ==",
             "requires": {
                 "typescript": "4.6.3",
                 "xml2js": "^0.4.23"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-cli",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "description": "Command line tools for the Thingworx VSCode Project",
     "bin": {
         "twc": "dist/index.js"
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "adm-zip": "0.5.9",
-        "bm-thing-transformer": "1.5.1",
+        "bm-thing-transformer": "1.6.0",
         "dotenv": "^16.0.0",
         "enquirer": "^2.3.6",
         "typescript": "4.6.3",

--- a/src/Utilities/TWClient.ts
+++ b/src/Utilities/TWClient.ts
@@ -337,7 +337,7 @@ export class TWClient {
      *                      the operation finishes.
      */
     static async getEntity(name: string, kind: string): Promise<TWClientResponse> {
-        const url = `${kind}/${name}${kind == 'Resources' ? '/metadata' : ''}`;
+        const url = `${kind}/${name}${kind == 'Resources' ? '/Metadata' : ''}`;
         return await this._performRequest({url}, 'get');
     }
 

--- a/src/Utilities/TWMetadataParser.ts
+++ b/src/Utilities/TWMetadataParser.ts
@@ -532,7 +532,7 @@ export class TWMetadataParser {
         const sanitizedName = this.sanitizedEntityName('Resources', body.name);
         let declaration = `declare class ${sanitizedName} extends ResourceEntity {\n\n`;
 
-        for (const service of Object.values(body.effectiveShape.serviceDefinitions) as any[]) {
+        for (const service of Object.values(body.serviceDefinitions) as any[]) {
             declaration += `
     /**
      * ${service.description}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,8 @@ import { init } from './Scripts/init';
 import { upgrade } from './Scripts/upgrade';
 import { generateAPI } from './Scripts/generate-api';
 import * as fs from 'fs';
-import * as dotenv from 'dotenv';
+import 'dotenv/config';
 
-dotenv.config();
 const [, , command, ...args] = process.argv;
 
 Error.stackTraceLimit = 0;


### PR DESCRIPTION
Adds support for specifying which .env file to use. ([stefan-lacatus](https://github.com/stefan-lacatus)) 

Resolves an issue with the `install` command that caused an error to be thrown when attempting to import `Resource` entities.