### PR TITLE
Add support of XML only projects in multi-project repos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
             "version": "1.6.1",
             "license": "MIT",
             "dependencies": {
-                "adm-zip": "0.5.9",
-                "bm-thing-transformer": "1.6.1",
+                "adm-zip": "0.5.10",
+                "bm-thing-transformer": "1.6.2",
                 "dotenv": "^16.0.0",
                 "enquirer": "^2.3.6",
                 "typescript": "4.6.3",
@@ -20,29 +20,29 @@
                 "twc": "dist/index.js"
             },
             "devDependencies": {
-                "@types/adm-zip": "0.4.34",
-                "@types/node": "^17.0.17"
+                "@types/adm-zip": "0.5.0",
+                "@types/node": "^18.15.0"
             }
         },
         "node_modules/@types/adm-zip": {
-            "version": "0.4.34",
-            "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.4.34.tgz",
-            "integrity": "sha512-8ToYLLAYhkRfcmmljrKi22gT2pqu7hGMDtORP1emwIEGmgUTZOsaDjzWFzW5N2frcFRz/50CWt4zA1CxJ73pmQ==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.0.tgz",
+            "integrity": "sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/node": {
-            "version": "17.0.18",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.18.tgz",
-            "integrity": "sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==",
+            "version": "18.15.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
+            "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w==",
             "dev": true
         },
         "node_modules/adm-zip": {
-            "version": "0.5.9",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
-            "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==",
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+            "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
             "engines": {
                 "node": ">=6.0"
             }
@@ -56,9 +56,9 @@
             }
         },
         "node_modules/bm-thing-transformer": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.6.1.tgz",
-            "integrity": "sha512-uWw6G/nON+I/+4grDALXugRT/zqjfnOaOcXokRPBq1JPlfVqe40Yfb9TH/0PdcMa2lQFnUcL5ryy8iK9xjazJA==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.6.2.tgz",
+            "integrity": "sha512-K4FfWL+h3I8K5iGOKp0MWLtuqGpwd/76NR0EznElLBK37vXbboZIsAKG8DYdIbwwVNGwHGX8dGR3YqDWPKMKoQ==",
             "dependencies": {
                 "typescript": "4.6.3",
                 "xml2js": "^0.4.23"
@@ -123,24 +123,24 @@
     },
     "dependencies": {
         "@types/adm-zip": {
-            "version": "0.4.34",
-            "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.4.34.tgz",
-            "integrity": "sha512-8ToYLLAYhkRfcmmljrKi22gT2pqu7hGMDtORP1emwIEGmgUTZOsaDjzWFzW5N2frcFRz/50CWt4zA1CxJ73pmQ==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.0.tgz",
+            "integrity": "sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==",
             "dev": true,
             "requires": {
                 "@types/node": "*"
             }
         },
         "@types/node": {
-            "version": "17.0.18",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.18.tgz",
-            "integrity": "sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==",
+            "version": "18.15.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
+            "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w==",
             "dev": true
         },
         "adm-zip": {
-            "version": "0.5.9",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
-            "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg=="
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+            "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ=="
         },
         "ansi-colors": {
             "version": "4.1.1",
@@ -148,9 +148,9 @@
             "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
         },
         "bm-thing-transformer": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.6.1.tgz",
-            "integrity": "sha512-uWw6G/nON+I/+4grDALXugRT/zqjfnOaOcXokRPBq1JPlfVqe40Yfb9TH/0PdcMa2lQFnUcL5ryy8iK9xjazJA==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-1.6.2.tgz",
+            "integrity": "sha512-K4FfWL+h3I8K5iGOKp0MWLtuqGpwd/76NR0EznElLBK37vXbboZIsAKG8DYdIbwwVNGwHGX8dGR3YqDWPKMKoQ==",
             "requires": {
                 "typescript": "4.6.3",
                 "xml2js": "^0.4.23"

--- a/package.json
+++ b/package.json
@@ -21,13 +21,16 @@
         "license",
         "readme"
     ],
+    "engines": {
+        "node": ">=18.0.0"
+    },
     "devDependencies": {
-        "@types/adm-zip": "0.4.34",
-        "@types/node": "^17.0.17"
+        "@types/adm-zip": "0.5.0",
+        "@types/node": "^18.15.0"
     },
     "dependencies": {
-        "adm-zip": "0.5.9",
-        "bm-thing-transformer": "1.6.1",
+        "adm-zip": "0.5.10",
+        "bm-thing-transformer": "1.6.2",
         "dotenv": "^16.0.0",
         "enquirer": "^2.3.6",
         "typescript": "4.6.3",

--- a/src/Commands/Commands.ts
+++ b/src/Commands/Commands.ts
@@ -60,4 +60,9 @@ export const enum Commands {
      * The upgrade command that upgrades from a gulpfile build system to a bm-thing-cli build system.
      */
     upgrade = 'upgrade',
+
+    /**
+     * The export command exports project entities from the server as XML files
+     */
+    export = 'export',
 }

--- a/src/Scripts/add-project.ts
+++ b/src/Scripts/add-project.ts
@@ -1,7 +1,7 @@
 import Enquirer from "enquirer";
 import * as FS from 'fs';
 import { TWConfig } from 'bm-thing-transformer';
-import { TSUtilities } from "../Utilities/TSUtilities";
+import { TWProjectUtilities } from "../Utilities/TWProjectUtilities";
 
 /**
  * Adds a project to the repository. If the repository is in single-project mode,
@@ -49,7 +49,7 @@ export async function addProject(): Promise<void> {
         FS.rmSync(`${cwd}/src`, {recursive: true, force: true});
 
         // Then copy into the appropriate subfolder in src and clear the temporary folder
-        TSUtilities.ensurePath(`${cwd}/src/${projectName}/src`, cwd);
+        TWProjectUtilities.ensurePath(`${cwd}/src/${projectName}/src`, cwd);
         FS.cpSync(`${cwd}/tmp`, `${cwd}/src/${projectName}/src`, {recursive: true});
         FS.rmSync(`${cwd}/tmp`, {recursive: true, force: true});
 

--- a/src/Scripts/build.ts
+++ b/src/Scripts/build.ts
@@ -33,9 +33,13 @@ export async function build(): Promise<DeploymentEndpoint[]> {
     const isEntityImport = args.includes("--entityImport") || args.includes("--entity-import") ;
 
     if (twConfig.projectName == '@auto') {
-        // If both modes are specified throw an error
+        // If both modes merged and separate are specified throw an error
         if (isMerged && isSeparate) {
             throw new Error(`🛑 \x1b[1;31mThe --merged and --separate arguments cannot be used together.\x1b[0m`);
+        }
+        // Having merged and entityImport specified makes no sense, since entityImport would end up ignored
+        if (isMerged && isEntityImport) {
+            throw new Error(`🛑 \x1b[1;31mThe --entityImport and --merged arguments cannot be used together.\x1b[0m`);
         }
     }
 

--- a/src/Scripts/build.ts
+++ b/src/Scripts/build.ts
@@ -234,8 +234,8 @@ export async function build(): Promise<DeploymentEndpoint[]> {
         }
 
 
-        // Emit the metadata.xml file if the user wants to package everything as extensions
-        if (!isEntityImport) {
+        // Emit the metadata.xml for typescript projects and for xml projects with entity import is disabled
+        if (project.type == TWProjectType.Typescript || (!isEntityImport && project.type == TWProjectType.XML_ONLY)) {
             // Copy and update the metadata file
             const metadataFile = FS.readFileSync(`${process.cwd()}/metadata.xml`, 'utf8');
             const metadataXML = await parseStringPromise(metadataFile);

--- a/src/Scripts/declarations.ts
+++ b/src/Scripts/declarations.ts
@@ -1,7 +1,7 @@
 import { TWThingTransformerFactory, TWConfig } from 'bm-thing-transformer';
 import * as FS from 'fs';
 import * as ts from 'typescript';
-import { TSUtilities } from '../Utilities/TSUtilities';
+import { TWProjectUtilities } from '../Utilities/TWProjectUtilities';
 
 /**
  * Builds the thingworx collection declarations of the thingworx project.
@@ -41,7 +41,7 @@ export function declarations() {
         twConfig.store = {};
     
         // Create the typescript project and emit using a "watch" transformer
-        const program = TSUtilities.programWithPath(path);
+        const program = TWProjectUtilities.programWithPath(path);
         const tsFiles = program.getSourceFiles().filter(file => !file.fileName.endsWith('.d.ts'));
         for (const file of tsFiles) {
             ts.transform(file, [TWThingTransformerFactory(program, path, false, true, twConfig)], program.getCompilerOptions());
@@ -58,17 +58,17 @@ export function declarations() {
         }
 
         // Write the declarations to a .d.ts file
-        TSUtilities.ensurePath(`${path}/static/gen`, path);
+        TWProjectUtilities.ensurePath(`${path}/static/gen`, path);
         FS.writeFileSync(`${path}/static/gen/Generated.d.ts`, declarations);
     }
     
     const cwd = process.cwd();
     
     if (twConfig.projectName == '@auto') {
-        TSUtilities.ensurePath(`${cwd}/src/static/gen`, cwd);
+        TWProjectUtilities.ensurePath(`${cwd}/src/static/gen`, cwd);
         FS.writeFileSync(`${cwd}/src/static/gen/Generated.d.ts`, getMethodHelperDeclarations());
         // If running in multi-project mode, run against each project separately
-        TSUtilities.projects().forEach(p => {
+        TWProjectUtilities.projects().forEach(p => {
             emitDeclarationsOfProject(p.path);
         });
     }

--- a/src/Scripts/declarations.ts
+++ b/src/Scripts/declarations.ts
@@ -1,7 +1,7 @@
 import { TWThingTransformerFactory, TWConfig } from 'bm-thing-transformer';
 import * as FS from 'fs';
 import * as ts from 'typescript';
-import { TWProjectUtilities } from '../Utilities/TWProjectUtilities';
+import { TWProjectType, TWProjectUtilities } from '../Utilities/TWProjectUtilities';
 
 /**
  * Builds the thingworx collection declarations of the thingworx project.
@@ -16,22 +16,22 @@ export function declarations() {
     function getMethodHelperDeclarations(): string {
         let declarations = '';
         if (twConfig.methodHelpers) {
-            if(twConfig.methodHelpers.methodName) {
+            if (twConfig.methodHelpers.methodName) {
                 declarations += `\n/**\n * Contains the name of the service or subscription being executed\n */\ndeclare const METHOD_NAME: string;\n`;
             }
-            if(twConfig.methodHelpers.className) {
+            if (twConfig.methodHelpers.className) {
                 declarations += `\n/**\n * Contains the name of the typescript class this service is a part of\n */\ndeclare const CLASS_NAME: string;\n`;
             }
-            if(twConfig.methodHelpers.filePath) {
+            if (twConfig.methodHelpers.filePath) {
                 declarations += `\n/**\n * Contains the relative file path of the to the file that contains this service\n */\ndeclare const FILE_PATH: string;\n`;
             }
-            if(twConfig.methodHelpers.logPrefix) {
+            if (twConfig.methodHelpers.logPrefix) {
                 declarations += `\n/**\n * Prefix that can be used in all log messages to identify the message source \n */\ndeclare const LOG_PREFIX: string;\n`;
             }
         }
         return declarations;
     }
-    
+
     /**
      * Emits the declarations of the project at the given path.
      * @param path      The project's path.
@@ -39,17 +39,17 @@ export function declarations() {
     function emitDeclarationsOfProject(path: string): void {
         // Create a new store for each project
         twConfig.store = {};
-    
+
         // Create the typescript project and emit using a "watch" transformer
         const program = TWProjectUtilities.programWithPath(path);
         const tsFiles = program.getSourceFiles().filter(file => !file.fileName.endsWith('.d.ts'));
         for (const file of tsFiles) {
             ts.transform(file, [TWThingTransformerFactory(program, path, false, true, twConfig)], program.getCompilerOptions());
         }
-    
+
         // Accumulate the declarations into a single file
         let declarations = twConfig.projectName != '@auto' ? getMethodHelperDeclarations() : '';
-        
+
         for (const key in twConfig.store) {
             // Keys starting with @ are non-entity entries
             if (key.startsWith('@')) continue;
@@ -61,16 +61,16 @@ export function declarations() {
         TWProjectUtilities.ensurePath(`${path}/static/gen`, path);
         FS.writeFileSync(`${path}/static/gen/Generated.d.ts`, declarations);
     }
-    
+
     const cwd = process.cwd();
-    
+
     if (twConfig.projectName == '@auto') {
         TWProjectUtilities.ensurePath(`${cwd}/src/static/gen`, cwd);
         FS.writeFileSync(`${cwd}/src/static/gen/Generated.d.ts`, getMethodHelperDeclarations());
         // If running in multi-project mode, run against each project separately
-        TWProjectUtilities.projects().forEach(p => {
-            emitDeclarationsOfProject(p.path);
-        });
+        TWProjectUtilities.projects()
+            .filter(p => p.type == TWProjectType.Typescript)
+            .forEach(p => { emitDeclarationsOfProject(p.path); });
     }
     else {
         // If running in single project mode, run against the whole repository

--- a/src/Scripts/export.ts
+++ b/src/Scripts/export.ts
@@ -1,0 +1,58 @@
+import * as FS from 'fs';
+import * as Path from 'path';
+import { TWConfig } from 'bm-thing-transformer';
+import { TWProjectType, TWProjectUtilities } from '../Utilities/TWProjectUtilities';
+import { TWClient } from '../Utilities/TWClient';
+import AdmZip from 'adm-zip';
+
+/**
+ * Exports xml files from thingworx into the target folders
+ */
+export async function exportCommand(): Promise<void> {
+    // Load the twconfig file which contains compilation options.
+    const twConfig = require(`${process.cwd()}/twconfig.json`) as TWConfig;
+
+    if (twConfig.projectName == '@auto') {
+        // In multi-project mode, export each xml-only project
+        for (const project of TWProjectUtilities.projects()) {
+            if (project.type == TWProjectType.XML_ONLY) {
+                exportProjectToFolder(Path.join(project.path, 'src'), project.name);
+            }
+        };
+    }
+    else {
+        throw new Error('Exports are only supported in multi-project mode')
+    }
+}
+
+/**
+ * Exports a given ThingWorx project into a local folder
+ * @param path Path to where the exported XMLs are emitted
+ * @param projectName Name of the ThingWorx project to export
+ */
+async function exportProjectToFolder(path: string, projectName: string) {
+    process.stdout.write(`\x1b[2m❯\x1b[0m Exporting ${projectName} from ${TWClient.server} to path ${path}`);
+
+    // Details for where the entities are imported into thingworx
+    const REPOSITORY_NAME = process.env.THINGWORX_REPO ?? 'SystemRepository';
+    const REPOSITORY_PATH = process.env.THINGWORX_REPO_PATH ?? '/';
+
+    // step 1: ask twx to do a source control export, and get the link to the zip file
+    const fileUrl = await TWClient.sourceControlExport(projectName, REPOSITORY_NAME, REPOSITORY_PATH, projectName);
+    // step 2: download the file from thingworx
+    if (!FS.existsSync("temp")) {
+        FS.mkdirSync("temp");
+    }
+    await TWClient.downloadFile(fileUrl, `temp/${projectName}.zip`);
+    // step 3: Unzip the file into the target folder
+    var zip = new AdmZip(`temp/${projectName}.zip`);
+    // The Zip file will contain a subfolder with the project name
+    zip.extractAllTo('temp', true);
+    // Move the contents of that folder into the project path
+    FS.cpSync(`temp/${projectName}`, path, { recursive: true, });
+    // step 4: cleanup
+    FS.rmSync("temp", { recursive: true, force: true })
+    await TWClient.deleteRemoteDirectory(REPOSITORY_NAME, `${REPOSITORY_PATH}/${projectName}`);
+
+    process.stdout.write(`\r\x1b[1;32m✔\x1b[0m Exported ${projectName} from ${TWClient.server} to path ${path} \n`);
+}

--- a/src/Scripts/generate-api.ts
+++ b/src/Scripts/generate-api.ts
@@ -1,7 +1,7 @@
 import { TWThingTransformerFactory, TWConfig, TWEntityKind } from 'bm-thing-transformer';
 import * as FS from 'fs';
 import * as ts from 'typescript';
-import { TSUtilities } from '../Utilities/TSUtilities';
+import { TWProjectUtilities } from '../Utilities/TWProjectUtilities';
 import { APIGenerator } from '../Utilities/APIDeclarationGenerator';
 
 /**
@@ -23,7 +23,7 @@ export function generateAPI() {
     twConfig.store = {};
 
     // Create the typescript project and emit using a transformer
-    const program = TSUtilities.programWithPath(cwd);
+    const program = TWProjectUtilities.programWithPath(cwd);
     const tsFiles = program.getSourceFiles().filter(file => !file.fileName.endsWith('.d.ts'));
     for (const file of tsFiles) {
         ts.transform(file, [TWThingTransformerFactory(program, cwd, false, false, twConfig)], program.getCompilerOptions());
@@ -99,7 +99,7 @@ export function generateAPI() {
     `;
 
     // Write the declarations to a .d.ts file
-    TSUtilities.ensurePath(`${cwd}/api`, cwd);
+    TWProjectUtilities.ensurePath(`${cwd}/api`, cwd);
     FS.writeFileSync(`${cwd}/api/Generated.d.ts`, declarations);
     FS.writeFileSync(`${cwd}/api/Runtime.ts`, runtime);
 

--- a/src/Scripts/remove.ts
+++ b/src/Scripts/remove.ts
@@ -1,5 +1,5 @@
 import { TWConfig } from 'bm-thing-transformer';
-import { TSProject, TSUtilities } from '../Utilities/TSUtilities';
+import { TWProject, TWProjectUtilities } from '../Utilities/TWProjectUtilities';
 import { TWClient } from '../Utilities/TWClient';
 
 const [, , , ...args] = process.argv;
@@ -23,7 +23,7 @@ export async function remove(): Promise<void> {
 
     if (twConfig.projectName == '@auto' && isSeparate) {
         // Remove the projects in the order of their dependencies
-        for (const project of TSUtilities.dependencySortedProjects()) {
+        for (const project of TWProjectUtilities.dependencySortedProjects()) {
             let projectPackageName = `${packageName}-${project.name}`;
             await uninstallPackage(projectPackageName);
         }

--- a/src/Scripts/upload.ts
+++ b/src/Scripts/upload.ts
@@ -1,7 +1,7 @@
 import * as FS from 'fs';
 import * as Path from 'path';
 import { TWConfig } from 'bm-thing-transformer';
-import { TSUtilities } from '../Utilities/TSUtilities';
+import { TWProjectUtilities } from '../Utilities/TWProjectUtilities';
 import { TWClient } from '../Utilities/TWClient';
 import AdmZip from 'adm-zip';
 
@@ -54,7 +54,7 @@ export async function upload(): Promise<void> {
 
     if (isSeparate && twConfig.projectName == '@auto') {
         // In separate mode, it is necessary to upload the projects in dependency order
-        for (const project of TSUtilities.dependencySortedProjects().reverse()) {
+        for (const project of TWProjectUtilities.dependencySortedProjects().reverse()) {
             const zipName = `${packageJSON.name}-${project.name}-${packageJSON.version}.zip`;
 
             await uploadZip(`${cwd}/zip/projects/${zipName}`, project.name);

--- a/src/Scripts/upload.ts
+++ b/src/Scripts/upload.ts
@@ -76,9 +76,13 @@ export async function upload(): Promise<void> {
 async function uploadZip(path: string, name?: string): Promise<void> {
     process.stdout.write(`\x1b[2m❯\x1b[0m Uploading${name ? ` ${name}` : ''} to ${TWClient.server}`);
 
-    const formData = {
-        file: FS.createReadStream(path)
-    };
+   const formData = new FormData();
+
+   formData.append(
+     "file",
+     new Blob([FS.readFileSync(path)]),
+     path.toString().split("/").pop()
+   );
 
     const response = await TWClient.importExtension(formData);
 

--- a/src/Scripts/upload.ts
+++ b/src/Scripts/upload.ts
@@ -2,7 +2,7 @@ import * as FS from 'fs';
 import * as Path from 'path';
 import readline from 'readline';
 import { TWConfig } from 'bm-thing-transformer';
-import { TWProjectUtilities } from '../Utilities/TWProjectUtilities';
+import { TWProjectType, TWProjectUtilities } from '../Utilities/TWProjectUtilities';
 import { TWClient } from '../Utilities/TWClient';
 import AdmZip from 'adm-zip';
 
@@ -61,7 +61,7 @@ export async function upload(): Promise<void> {
         for (const project of TWProjectUtilities.dependencySortedProjects().reverse()) {
             const zipName = `${packageJSON.name}-${project.name}-${packageJSON.version}.zip`;
             // Import either as an extension or a source control entities
-            if (isEntityImport) {
+            if (project.type == TWProjectType.XML_ONLY && isEntityImport) {
                 await importSourceControlledZip(`${cwd}/zip/projects/`, zipName, project.name);
             } else {
                 await importExtension(`${cwd}/zip/projects/${zipName}`, project.name);
@@ -69,13 +69,9 @@ export async function upload(): Promise<void> {
         };
     }
     else {
-        // In merged mode, just upload the resulting zip
+        // In merged mode, just upload the resulting zip as extension
         const zipName = `${packageJSON.name}-${packageJSON.version}.zip`;
-        if (isEntityImport) {
-            await importSourceControlledZip(`${cwd}/zip/`, zipName, packageJSON.name);
-        } else {
-            await importExtension(`${cwd}/zip/${zipName}`);
-        }
+        await importExtension(`${cwd}/zip/${zipName}`);
     }
 }
 

--- a/src/Scripts/upload.ts
+++ b/src/Scripts/upload.ts
@@ -1,5 +1,6 @@
 import * as FS from 'fs';
 import * as Path from 'path';
+import readline from 'readline';
 import { TWConfig } from 'bm-thing-transformer';
 import { TWProjectUtilities } from '../Utilities/TWProjectUtilities';
 import { TWClient } from '../Utilities/TWClient';
@@ -23,10 +24,6 @@ export async function upload(): Promise<void> {
     // When the entity import flag is specified, don't import zip files as extensions, but rather as 
     // source control entity imports
     const isEntityImport = args.includes("--entityImport") || args.includes("--entity-import");
-    
-    if (isEntityImport) {
-        process.stdout.write(`\r\x1b[1;32m✔\x1b[0m Importing project as entities using source control import \n`);
-    }
 
     // Load the twconfig file which contains the version and package name information.
     const packageJSON = require(`${process.cwd()}/package.json`);
@@ -89,6 +86,8 @@ export async function upload(): Promise<void> {
  * @param projectName Name of the project being uploaded
  */
 async function importSourceControlledZip(path: string, zipName: string, projectName: string) {
+    process.stdout.write(`\x1b[2m❯\x1b[0m Uploading ${projectName} to ${TWClient.server} as entities`);
+
     // Details for where the entities are imported into thingworx
     const REPOSITORY_NAME = process.env.THINGWORX_REPO ?? 'SystemRepository';
     const REPOSITORY_PATH = process.env.THINGWORX_REPO_PATH ?? '/';
@@ -101,6 +100,9 @@ async function importSourceControlledZip(path: string, zipName: string, projectN
     await TWClient.sourceControlImport(projectName, REPOSITORY_NAME, `${REPOSITORY_PATH}/${projectName}`,);
     // step 4: cleanup
     await TWClient.deleteRemoteDirectory(REPOSITORY_NAME, `${REPOSITORY_PATH}/${projectName}`);
+    
+    readline.clearLine(process.stdout, -1);
+    process.stdout.write(`\r\x1b[1;32m✔\x1b[0m Uploaded ${projectName} to ${TWClient.server} as entities \n`);
 }
 
 /**

--- a/src/Scripts/zip.ts
+++ b/src/Scripts/zip.ts
@@ -1,7 +1,7 @@
 import { TWConfig } from 'bm-thing-transformer';
 import * as FS from 'fs';
 import AdmZip from 'adm-zip';
-import { TSUtilities } from '../Utilities/TSUtilities';
+import { TWProjectUtilities } from '../Utilities/TWProjectUtilities';
 
 const [, , command, ...args] = process.argv;
 
@@ -60,7 +60,7 @@ export async function zip(): Promise<void> {
         if (!FS.existsSync(baseOutPath)) FS.mkdirSync(baseOutPath)
 
         // Zip each project
-        for (const p of TSUtilities.projects()) {
+        for (const p of TWProjectUtilities.projects()) {
             const zipName = `${packageJSON.name}-${p.name}-${packageJSON.version}.zip`;
             const path = `${cwd}/build/${p.name}`;
             await zipPath(zipName, path, baseOutPath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { install } from './Scripts/install';
 import { init } from './Scripts/init';
 import { upgrade } from './Scripts/upgrade';
 import { generateAPI } from './Scripts/generate-api';
+import { exportCommand } from './Scripts/export';
 import * as fs from 'fs';
 import 'dotenv/config';
 
@@ -92,6 +93,9 @@ async function main() {
         case Commands.generateAPI:
             await generateAPI();
             break;
+        case Commands.export:
+            await exportCommand();
+            break;
         default:
             console.error(`Unknown command "${command}" specified.`);
     }
@@ -116,10 +120,10 @@ Available commands:
  * \x1b[1mbuild\x1b[0m [--merged] [--separate] [--debug] [--trace]
    Builds the thingworx extension
 
- * \x1b[1mupload\x1b[0m [--merged] [--separate] [--debug] [--trace] [--extensions] [--remove] [--retain-version]
+ * \x1b[1mupload\x1b[0m [--merged] [--separate] [--debug] [--trace] [--extensions] [--remove] [--retain-version] [--entity-import]
    Builds and uploads the thingworx extension
 
- * \x1b[1mdeploy\x1b[0m [--merged] [--separate] [--debug] [--trace] [--extensions] [--remove] [--retain-version]
+ * \x1b[1mdeploy\x1b[0m [--merged] [--separate] [--debug] [--trace] [--extensions] [--remove] [--retain-version] [--entity-import]
    Uploads the extension then runs deployment scripts
 
  * \x1b[1mremove\x1b[0m [--merged] [--separate]
@@ -127,6 +131,9 @@ Available commands:
 
  * \x1b[1madd-project\x1b[0m
    Adds a new project to the repository
+
+ * \x1b[1mexport\x1b[0m
+   Exports xml only projects from the thingworx server 
 
  * \x1b[1mgenerate-api\x1b[0m
    EXPERIMENTAL: Builds declarations out of exported entities that can be used in other projects
@@ -137,3 +144,4 @@ Available commands:
  * \x1b[1mupgrade\x1b[0m
    Upgrades from a gulp project to a twc project`);
 }
+


### PR DESCRIPTION
## Intent

- Support for multi-project repositories that include projects in typescript and projects that contain only XML entities (referred to `XML_ONLY`)
- This makes it possible to have a repository that has a ThingWorx project written in typescript (like the backend) and another that has only XML entities (like the mashups)
- Add utility commands:
   -  `twc upload --entity-import` that packages and uploads the `XML_ONLY` projects using `SourceControlImport`
   -  `twc export` that exports all `XML_ONLY` projects and updates the local XML files

## Implementation

-  `XML_ONLY` projects are only supported in multi-project mode (when `twconfig.json` `projectName` is set to `@auto`)
    - A project is classified being a `Typescript` project if it has ` tsconfig.json` file in its root folder.
    - A project is classified as being `XML_ONLY` if there is no `tsconfing.json`, and a `twconfig.json` file exists in its root folder.
   - At the moment, the contents of the `twconfig.json` file are not used. In the future they could be used to specify the project dependencies
- Migrate to using node 18 native fetch instead of the "custom" http client written on top of the native node `http` and `https` objects. (https://github.com/BogdanMihaiciuc/ThingCLI/commit/887475a6b44a83a3b60106c0f9966cfefcfeeac1). This means that **node 18 (which is now LTS), is the minimum supported version**. This change was needed to more easily support uploads into the file repositories. 
-  Added `twc export` command. This iterates through all `XML_ONLY` projects and exports their entities from thingworx. The export process is optimized to work against remote servers by exporting into the local ThingWorx file repository, zipping up the XML files, then downloading a single file and extracting it.
- Added a new flag, `--entity-import` for the `build`, `upload` and `deploy` commands. This applies to `XML_ONLY` projects.
   - For `build`:
       - It omits generating a `metadata.xml`
   - For `upload` and `deploy`
       - It uploads the `XML_ONLY` projects  as source control entities, and not as an extension. 
       - This is optimized for remote servers, by uploading the zip file into a ThingWorx FileRepository, and importing the files from there.