### PR TITLE
fix: don't zip projects that are not included in the project list

### DIFF
--- a/src/Scripts/zip.ts
+++ b/src/Scripts/zip.ts
@@ -59,8 +59,14 @@ export async function zip(): Promise<void> {
         // Ensure that the base out path exists
         if (!FS.existsSync(baseOutPath)) FS.mkdirSync(baseOutPath)
 
+        // List of projects included in the build
+        const projects = TWProjectUtilities.projectsWithArguments(args);
+
         // Zip each project
         for (const p of TWProjectUtilities.projects()) {
+            if (projects && !projects.includes(p.name)) {
+              continue;
+            }
             const zipName = `${packageJSON.name}-${p.name}-${packageJSON.version}.zip`;
             const path = `${cwd}/build/${p.name}`;
             await zipPath(zipName, path, baseOutPath);


### PR DESCRIPTION
This fixes an issue where uploading a multi project repository would fail the initial upload into the server because the folder for the skipped projects would be missing.