### PR TITLE
Progress bar improvements

### DIFF
--- a/src/Utilities/ProgressBar.ts
+++ b/src/Utilities/ProgressBar.ts
@@ -60,23 +60,10 @@ export class ProgressBar {
     private loggingBuffer: string[] = [];
 
     /**
-     * A callback that is invoked on SIGINT and SIGTERM while the progress bar is running.
-     * Reenables the cursor and exists the process.
-     */
-    private _sigintHandler = () => {
-        process.stdout.write('\u001B[?25h');
-        process.exit(1);
-    };
-
-    /**
      * Draws the progress bar. Until invoking `stop`, you should not write to stdout.
      */
     start() {
         this._render();
-
-        // Reenable the cursor if the process stops
-        process.once('SIGINT', this._sigintHandler);
-        process.once('SIGTERM', this._sigintHandler);
     }
 
     /**
@@ -129,7 +116,7 @@ export class ProgressBar {
         }
 
         // Close the bar and draw the message, then hide the cursor
-        process.stdout.write(`${EndSymbol} | ${(this._progress * 100) | 0}%\n\x1b[2m${this._message}\x1b[0m\u001B[?25l`);
+        process.stdout.write(`${EndSymbol} | ${(this._progress * 100) | 0}%\n\x1b[2m${this._message}\x1b[0m`);
     }
 
     /**
@@ -151,10 +138,7 @@ export class ProgressBar {
      * Stops the progress bar, moves the cursor to the next line and shows it.
      */
     stop() {
-        process.stdout.write('\n\u001B[?25h');
-
-        process.off('SIGINT', this.destroy);
-        process.off('SIGTERM', this.destroy);
+        process.stdout.write('\n');
     }
 
     /**

--- a/src/Utilities/ProgressBar.ts
+++ b/src/Utilities/ProgressBar.ts
@@ -54,12 +54,18 @@ export class ProgressBar {
     private _normalizedProgress: number = 0;
 
     /**
-     * A callback that is invoked on SIGINT while the progress bar is running.
-     * Reenables the cursor.
+     * A buffer containing the messages that should be displayed below the
+     * progress bar.
+     */
+    private loggingBuffer: string[] = [];
+
+    /**
+     * A callback that is invoked on SIGINT and SIGTERM while the progress bar is running.
+     * Reenables the cursor and exists the process.
      */
     private _sigintHandler = () => {
         process.stdout.write('\u001B[?25h');
-        process.exit();
+        process.exit(1);
     };
 
     /**
@@ -69,7 +75,8 @@ export class ProgressBar {
         this._render();
 
         // Reenable the cursor if the process stops
-        process.on('SIGINT', this._sigintHandler);
+        process.once('SIGINT', this._sigintHandler);
+        process.once('SIGTERM', this._sigintHandler);
     }
 
     /**
@@ -86,6 +93,18 @@ export class ProgressBar {
      * Renders this progress bar at the current cursor position.
      */
     private _render() {
+        // content within logging buffer ?
+        if (this.loggingBuffer.length > 0) {
+            readline.clearLine(process.stdout, 0);
+
+            // flush logging buffer and write content to terminal
+            while (this.loggingBuffer.length > 0) {
+                const message = this.loggingBuffer.shift();
+                if (message) {
+                    process.stdout.write(message + '\n');
+                }
+            }
+        }
         // Draw the beginning of the bar
         process.stdout.write(StartSymbol);
 
@@ -129,23 +148,31 @@ export class ProgressBar {
     }
 
     /**
-     * Moves the cursor to the next line.
+     * Stops the progress bar, moves the cursor to the next line and shows it.
      */
     stop() {
         process.stdout.write('\n\u001B[?25h');
 
-        process.off('SIGINT', this._sigintHandler);
+        process.off('SIGINT', this.destroy);
+        process.off('SIGTERM', this.destroy);
     }
 
     /**
      * Clears the progress bar and moves the cursor back to where the progress
      * bar started.
      */
-    destroy() {
+    destroy = () => {
+        this.stop();
         this._clear();
-        process.stdout.write('\n\u001B[?25h');
+    }
 
-        process.off('SIGINT', this._sigintHandler);
+    /**
+     * Logs a message to the console, that appears above the progress bar.
+     * @param message String to log 
+     */
+    log(message: string) {
+        // push content into logging buffer
+        this.loggingBuffer.push(message);
     }
 
 }


### PR DESCRIPTION
This change fixes issue with hitting Ctrl+C (stopping the program) while a progress bar is visible, and contains some cherry-picked commits from #32 

Note that this is actually a node bug, because as soon as a SIGINT handler is added, it becomes part of the node event loop.

If the event loop is busy, it won't end up being called. See https://github.com/nodejs/node/issues/9050

The solution is to actually not have any SIGINT handler.

Additionally, since we have no way of restoring it, we are also not hiding the cursor any more