### PR TITLE
2.1.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 2.1.7
+
+Updates to transformer 2.1.7 which resolves an issue where binding could require type assertions and an issue where core ui controllers could not bind their infotable properties to other widgets.
+
+When building progress, the progress bar cursor will now appear on a separate line instead of flashing at the end of the current file name.
+
 # 2.1.6
 
 Updates to transformer 2.1.6 which resolves issues with binding to and from mashup parameters and `Navigationfunction` parameters.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "bm-thing-cli",
-    "version": "2.1.6",
+    "version": "2.1.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "bm-thing-cli",
-            "version": "2.1.6",
+            "version": "2.1.7",
             "license": "MIT",
             "dependencies": {
                 "adm-zip": "0.5.10",
-                "bm-thing-transformer": "2.1.6",
+                "bm-thing-transformer": "2.1.7",
                 "dotenv": "^16.0.0",
                 "enquirer": "^2.3.6",
                 "typescript": "5.4.5",
@@ -59,9 +59,10 @@
             }
         },
         "node_modules/bm-thing-transformer": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-2.1.6.tgz",
-            "integrity": "sha512-Dqb4rc0myzxigBMotdDYroHcZBaD7g9EZH5C6XFt2phz5qgBx4GwshRyolN/q93hyr/FqtmZCMmg2/bdOlOrZQ==",
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-2.1.7.tgz",
+            "integrity": "sha512-T94iWKEPmH2LNjCGFnvSJwSPfBCf5wr8YTISU1rbNNUEdJowYeaBSIXQJ1ty7ZoOxo//lzOP5QKcCH5xCqie2w==",
+            "license": "MIT",
             "dependencies": {
                 "typescript": "5.4.5",
                 "typescriptwebpacksupport": "^2.4.0",
@@ -157,9 +158,9 @@
             "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
         },
         "bm-thing-transformer": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-2.1.6.tgz",
-            "integrity": "sha512-Dqb4rc0myzxigBMotdDYroHcZBaD7g9EZH5C6XFt2phz5qgBx4GwshRyolN/q93hyr/FqtmZCMmg2/bdOlOrZQ==",
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/bm-thing-transformer/-/bm-thing-transformer-2.1.7.tgz",
+            "integrity": "sha512-T94iWKEPmH2LNjCGFnvSJwSPfBCf5wr8YTISU1rbNNUEdJowYeaBSIXQJ1ty7ZoOxo//lzOP5QKcCH5xCqie2w==",
             "requires": {
                 "typescript": "5.4.5",
                 "typescriptwebpacksupport": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-cli",
-    "version": "2.1.6",
+    "version": "2.1.7",
     "description": "Command line tools for the Thingworx VSCode Project",
     "bin": {
         "twc": "dist/index.js"
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "adm-zip": "0.5.10",
-        "bm-thing-transformer": "2.1.6",
+        "bm-thing-transformer": "2.1.7",
         "dotenv": "^16.0.0",
         "enquirer": "^2.3.6",
         "typescript": "5.4.5",

--- a/src/Utilities/ProgressBar.ts
+++ b/src/Utilities/ProgressBar.ts
@@ -73,6 +73,8 @@ export class ProgressBar {
         readline.clearLine(process.stdout, -1);
         readline.moveCursor(process.stdout, 0, -1);
         readline.clearLine(process.stdout, 1);
+        readline.moveCursor(process.stdout, 0, -1);
+        readline.clearLine(process.stdout, 1);
         process.stdout.write('\r');
     }
 
@@ -116,7 +118,7 @@ export class ProgressBar {
         }
 
         // Close the bar and draw the message, then hide the cursor
-        process.stdout.write(`${EndSymbol} | ${(this._progress * 100) | 0}%\n\x1b[2m${this._message}\x1b[0m`);
+        process.stdout.write(`${EndSymbol} | ${(this._progress * 100) | 0}%\n\x1b[2m${this._message}\x1b[0m\n`);
     }
 
     /**


### PR DESCRIPTION
Updates to transformer 2.1.7 which resolves an issue where binding could require type assertions and an issue where core ui controllers could not bind their infotable properties to other widgets.

When building progress, the progress bar cursor will now appear on a separate line instead of flashing at the end of the current file name.