### PR TITLE
Resource entities are skipped during install command

### DIFF
--- a/src/Scripts/install.ts
+++ b/src/Scripts/install.ts
@@ -380,7 +380,7 @@ async function getExtension(name: string, slice: number, installProgress: Instal
     }
     else {
         // Otherwise, each entity has to be loaded separately
-        const entitiesToLoad = packageDetails.rows.filter(row => (row.parentName != 'Resources' && row.parentName != 'ThingPackages' && row.parentName != 'Widgets'));
+        const entitiesToLoad = packageDetails.rows.filter(row => (!(row.parentName == 'Resources' && row.name.endsWith('.jar')) && row.parentName != 'ThingPackages' && row.parentName != 'Widgets'));
         const entitySlice = slice / (entitiesToLoad.length + 1);
         installProgress.progress += entitySlice;
 


### PR DESCRIPTION


Extensions that contain resources are skipped and their declaration is not generated
![image](https://github.com/user-attachments/assets/c17afc04-8f8a-45ac-8869-d2a7e2a577ce)

It appears that the intention was to skip the jar files in extensions, but that also ended up skipping the actual Resources entities.

This works around it by skipping only the jar files