### PR TITLE
feat: add multi-project xml support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 2.3.0
+
+Adds support for multi-project XML folders. A `twconfig.json` in an XML project folder can now specify a `projects` array listing multiple ThingWorx project names that the folder represents. When pulling, all listed projects are fetched and their entities merged into the same `src` directory. When pushing, the folder contents are uploaded as before. Folders without a `projects` array continue to use the folder name as the single project name.
+
 # 2.2.0
 
 Adds the ability to upload files to repositories as part of the `upload`, `push` and `deploy` commands. This requires a `repositoryPath` property to be specified in the `twconfig.json` file. Additionally, when building projects, the `zip` folder will contain an additional zip file for each repository in all projects that were built.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bm-thing-cli",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "Command line tools for the Thingworx VSCode Project",
     "bin": {
         "twc": "dist/index.js"

--- a/readme.md
+++ b/readme.md
@@ -154,7 +154,7 @@ To build the project, run `npm run build` in the root of the project. This will 
 ### Contributors
 
  - [BogdanMihaiciuc](https://github.com/BogdanMihaiciuc): main developer
- - [stefan-lacatus](https://github.com/stefan-lacatus): pull and push commands, retainVersion argument, method helpers, generate-api command, bug fixes
+ - [stefan-lacatus](https://github.com/stefan-lacatus): pull and push commands, retainVersion argument, method helpers, generate-api command, bug fixes, multi-project xml folders
  - [CozminM](https://github.com/CozminM): compatiblity with thingworx 8.5
 
 #  License

--- a/src/Scripts/build.ts
+++ b/src/Scripts/build.ts
@@ -124,7 +124,7 @@ export async function build(push: boolean = false): Promise<DeploymentEndpoint[]
     else {
         // If running in single project mode, run against the whole repository, and assume it's typescript
         const outPath = `${cwd}/build`;
-        buildProject({ name: twConfig.projectName, path: cwd, kind: TWProjectKind.TypeScript, parentProjects: [] }, outPath);
+        buildProject({ name: twConfig.projectName, projectNames: [twConfig.projectName], path: cwd, kind: TWProjectKind.TypeScript, parentProjects: [] }, outPath);
     }
 
     /**

--- a/src/Scripts/pull.ts
+++ b/src/Scripts/pull.ts
@@ -30,7 +30,9 @@ export async function pull(): Promise<void> {
             }
 
             if (project.kind == TWProjectKind.XML) {
-                pullProjectToFolder(Path.join(project.path, 'src'), project.name);
+                for (const projectName of project.projectNames) {
+                    await pullProjectToFolder(Path.join(project.path, 'src'), projectName);
+                }
             }
         };
     }

--- a/src/Utilities/TWProjectUtilities.ts
+++ b/src/Utilities/TWProjectUtilities.ts
@@ -23,9 +23,15 @@ export enum TWProjectKind {
 export interface TWProject {
 
     /**
-     * The project's name.
+     * The project's name (folder name).
      */
     name: string;
+
+    /**
+     * The TWX project names this folder represents. For most projects this is just [name],
+     * but for multi-project folders it can list several TWX project names.
+     */
+    projectNames: string[];
 
     /**
      * The path to the project's root folder.
@@ -107,10 +113,15 @@ export class TWProjectUtilities {
             if (fs.lstatSync(path).isDirectory()) {
                 if(fs.existsSync(`${path}/tsconfig.json`)) {
                     // If a tsconfig.json file is found, then the project contains typescript entities
-                    projects.push({name: projectName, path, kind: TWProjectKind.TypeScript});
+                    projects.push({name: projectName, projectNames: [projectName], path, kind: TWProjectKind.TypeScript});
                 } else if(fs.existsSync(`${path}/twconfig.json`)) {
                     // If only a twconfig.json is found, then assume it's XML only
-                    projects.push({name: projectName, path, kind: TWProjectKind.XML});
+                    // The twconfig.json may specify multiple TWX project names via a "projects" array
+                    const folderTwConfig = JSON.parse(fs.readFileSync(`${path}/twconfig.json`, 'utf8') || '{}');
+                    const projectNames: string[] = Array.isArray(folderTwConfig.projects) && folderTwConfig.projects.length > 0
+                        ? folderTwConfig.projects
+                        : [projectName];
+                    projects.push({name: projectName, projectNames, path, kind: TWProjectKind.XML});
                 }
             }
         }


### PR DESCRIPTION
## Intent

- We have scenarios where a conceptual project is made out of multiple TWX projects that should be managed together under source control, as they may have intricate inter-dependencies that cause issues if stored in separate folders.
- Because the `push` command already handled this (you could just dump xml files and they would be uploaded together) it made a lot of sense to make it so the `pull` command also works in this scenario.
- So, now in `twconfig.json` you can specify an array of TWX projects the local folder represents.

## Implementation

- Only the pull command was updated to pull all TWX projects referenced